### PR TITLE
Fix NullPointer exception during scanning

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/data/Mappers.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/data/Mappers.kt
@@ -49,18 +49,18 @@ internal fun ScanRecord.toDomain(): BleScanRecord {
     return BleScanRecord(
         this.advertiseFlags,
         this.serviceUuids ?: emptyList(),
-        this.serviceData?.mapValues { DataByteArray(it.value) } ?: emptyMap(),
+        this.serviceData?.mapValues { DataByteArray(it.value ?: byteArrayOf()) } ?: emptyMap(),
         getSolicitationUuids(this),
         this.deviceName ?: "",
         this.txPowerLevel,
-        DataByteArray(this.bytes),
+        DataByteArray(this.bytes ?: byteArrayOf()),
         this.manufacturerSpecificData?.map { DataByteArray(it ?: byteArrayOf()) } ?: SparseArray()
     )
 }
 
 private fun getSolicitationUuids(scanRecord: ScanRecord): List<ParcelUuid> {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        scanRecord.serviceSolicitationUuids
+        scanRecord.serviceSolicitationUuids ?: emptyList() //Don't delete elvis operator.
     } else {
         emptyList()
     }


### PR DESCRIPTION
Fix NullPointerException which occurs during parsing scan result.

The issue has been observed on Firebase console, but because of limited 
information the true cause is unknown. To prevent the issue elvis operator
has been added to different elements of scan result's parsing.

Fatal Exception: java.lang.NullPointerException
no.nordicsemi.android.kotlin.ble.scanner.BleScanner$scan$1$scanCallback$1.onScanResult (BleScanner.kt:100)
android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper$1.run (BluetoothLeScanner.java:669)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)