### PR TITLE
Exposing `:blek:core` from `uiscanner` module

### DIFF
--- a/uiscanner/build.gradle.kts
+++ b/uiscanner/build.gradle.kts
@@ -57,6 +57,7 @@ android {
 }
 
 dependencies {
+    api(project(":core"))
     implementation(project(":scanner"))
 
     implementation(libs.nordic.theme)


### PR DESCRIPTION
As the `:uiscanner` module takes care of scanning, exposing `:scanner` is not necessary, I believe, but to get scan results the target app needs to have access to core classes.