### PR TITLE
Feat: receiver not exported

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -67,5 +67,6 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.core.ktx)
     api(libs.nordic.core)
 }

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/bonding/BondingBroadcastReceiver.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/bonding/BondingBroadcastReceiver.kt
@@ -40,6 +40,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
+import androidx.core.content.ContextCompat
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent.BondStateChanged
 import no.nordicsemi.android.kotlin.ble.client.real.ClientBleGattCallback
 import no.nordicsemi.android.kotlin.ble.core.BleDevice
@@ -55,7 +56,8 @@ class BondingBroadcastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         val action = intent?.action ?: return
         val device: BluetoothDevice = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java) ?: return
+            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+                ?: return
         } else @Suppress("DEPRECATION") {
             intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE) ?: return
         }
@@ -87,7 +89,12 @@ class BondingBroadcastReceiver : BroadcastReceiver() {
 
             if (instance == null) {
                 instance = BondingBroadcastReceiver()
-                context.applicationContext.registerReceiver(instance, IntentFilter(ACTION_BOND_STATE_CHANGED))
+                ContextCompat.registerReceiver(
+                    context.applicationContext,
+                    instance,
+                    IntentFilter(ACTION_BOND_STATE_CHANGED),
+                    ContextCompat.RECEIVER_NOT_EXPORTED
+                )
             }
         }
 

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/BleGattConnectionPriority.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/BleGattConnectionPriority.kt
@@ -12,22 +12,38 @@ import androidx.annotation.RequiresApi
 enum class BleGattConnectionPriority(val value: Int) {
 
     /**
-     * Connection parameter update - Use the connection parameters recommended by the Bluetooth SIG.
-     * This is the default value if no connection parameter update is requested.
+     * Connection parameter update - Use the connection parameters recommended by the
+     * Bluetooth SIG. This is the default value if no connection parameter update
+     * is requested.
+     * <p>
+     * Interval: 30 - 50 ms, latency: 0, supervision timeout: 5 sec (Android 8+) or 20 sec (before).
+     *
+     * @see <a href="https://android.googlesource.com/platform/packages/modules/Bluetooth/+/673c5903c4a920510c371af26e5870857a584ead%5E!">commit 673c5903c4a920510c371af26e5870857a584ead</a>
      */
     BALANCED(BluetoothGatt.CONNECTION_PRIORITY_BALANCED),
 
 
     /**
-     * Connection parameter update - Request a high priority, low latency connection. An application
-     * should only request high priority connection parameters to transfer large amounts of data
-     * over LE quickly. Once the transfer is complete, the application should request
-     * [BALANCED] connection parameters to reduce energy use.
+     * Connection parameter update - Request a high priority, low latency connection.
+     * An application should only request high priority connection parameters to transfer
+     * large amounts of data over LE quickly. Once the transfer is complete, the application
+     * should request [BALANCED] connection parameters
+     * to reduce energy use.
+     * <p>
+     * Interval: 11.25 - 15 ms (Android 6+) or 7.5 - 10 ms (Android 4.3 - 5.1),
+     * latency: 0, supervision timeout: 5 sec (Android 8+) or 20 sec (before).
+     *
+     * @see <a href="https://android.googlesource.com/platform/packages/modules/Bluetooth/+/4bc7c7e877c9d18f2781229c553b6144f9fd7236%5E%21/">commit 4bc7c7e877c9d18f2781229c553b6144f9fd7236</a>
+     * @see <a href="https://android.googlesource.com/platform/packages/modules/Bluetooth/+/673c5903c4a920510c371af26e5870857a584ead%5E!">commit 673c5903c4a920510c371af26e5870857a584ead</a>
      */
     HIGH(BluetoothGatt.CONNECTION_PRIORITY_HIGH),
 
     /**
      * Connection parameter update - Request low power, reduced data rate connection parameters.
+     * <p>
+     * Interval: 100 - 125 ms, latency: 2, supervision timeout: 5 sec (Android 8+) or 20 sec (before).
+     *
+     * @see <a href="https://android.googlesource.com/platform/packages/modules/Bluetooth/+/673c5903c4a920510c371af26e5870857a584ead%5E!">commit 673c5903c4a920510c371af26e5870857a584ead</a>
      */
     LOW_POWER(BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER),
 


### PR DESCRIPTION
- Register BondingBroadcastReceiver with RECEIVER_NOT_EXPORTED flag.
- Improve BleGattConnectionPriority docs.