### PR TITLE
Add a way to observe server disconnections

### DIFF
--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/ServerConnectionEvent.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/ServerConnectionEvent.kt
@@ -1,0 +1,9 @@
+package no.nordicsemi.android.kotlin.ble.server.main
+
+import no.nordicsemi.android.kotlin.ble.core.ClientDevice
+import no.nordicsemi.android.kotlin.ble.server.main.service.ServerBluetoothGattConnection
+
+sealed interface ServerConnectionEvent {
+    data class DeviceConnected(val connection : ServerBluetoothGattConnection): ServerConnectionEvent
+    data class DeviceDisconnected(val device: ClientDevice): ServerConnectionEvent
+}


### PR DESCRIPTION
Add a way to observe server disconnections

Before it was possible to observe disconnections by saving the map emitted by "connections" flow and comparing it to the last one received to see if any value was deleted, but this implementation should make this easier