### PR TITLE
Add a way to observe server disconnections

### DIFF
--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/ServerBleGatt.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/ServerBleGatt.kt
@@ -56,6 +56,7 @@ import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattService
 import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
 import no.nordicsemi.android.kotlin.ble.server.api.ServerGattEvent
 import no.nordicsemi.android.kotlin.ble.server.api.ServerGattEvent.*
+import no.nordicsemi.android.kotlin.ble.server.main.ServerConnectionEvent.*
 import no.nordicsemi.android.kotlin.ble.server.main.service.BluetoothGattServiceFactory
 import no.nordicsemi.android.kotlin.ble.server.main.service.ServerBleGattCharacteristic
 import no.nordicsemi.android.kotlin.ble.server.main.service.ServerBleGattDescriptor
@@ -103,13 +104,13 @@ class ServerBleGatt internal constructor(
         }
     }
 
-    private val _onNewConnection = simpleSharedFlow<ServerBluetoothGattConnection>()
+    private val _connectionEvents = simpleSharedFlow<ServerConnectionEvent>()
 
     /**
-     * [Flow] which emits each time a new connection is established.
+     * [Flow] which emits each time a new connection is established or lost.
      * It can be used to set up new connection's services behaviour.
      */
-    val onNewConnection = _onNewConnection.asSharedFlow()
+    val connectionEvents = _connectionEvents.asSharedFlow()
 
     private val _connections =
         MutableStateFlow(mapOf<ClientDevice, ServerBluetoothGattConnection>())
@@ -188,8 +189,10 @@ class ServerBleGatt internal constructor(
      */
     private fun removeDevice(device: ClientDevice) {
         val mutableMap = connections.value.toMutableMap()
-        mutableMap.remove(device)
-        _connections.value = mutableMap.toMap()
+        mutableMap.remove(device)?.let {
+            _connections.value = mutableMap.toMap()
+        }
+        _connectionEvents.tryEmit(DeviceDisconnected(device))
     }
 
     /**
@@ -211,7 +214,7 @@ class ServerBleGatt internal constructor(
             device, server, ServerBleGattServices(server, device, copiedServices)
         )
         mutableMap[device] = connection
-        _onNewConnection.tryEmit(connection)
+        _connectionEvents.tryEmit(DeviceConnected(connection))
         _connections.value = mutableMap.toMap()
 
         server.connect(device, true)

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/ServerConnectionEvent.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/ServerConnectionEvent.kt
@@ -1,0 +1,9 @@
+package no.nordicsemi.android.kotlin.ble.server.main
+
+import no.nordicsemi.android.kotlin.ble.core.ClientDevice
+import no.nordicsemi.android.kotlin.ble.server.main.service.ServerBluetoothGattConnection
+
+sealed interface ServerConnectionEvent {
+    data class DeviceConnected(val connection : ServerBluetoothGattConnection): ServerConnectionEvent
+    data class DeviceDisconnected(val device: ClientDevice): ServerConnectionEvent
+}


### PR DESCRIPTION
Add a way to observe server disconnections

Before it was possible to observe disconnections by saving the map emitted by "connections" flow and comparing it to the last one received to see if any value was deleted, but this implementation should make this easier

Tested by building the library and using it in my app. Usage is :
```kotlin
 serverBleGatt.connectionEvents
                .onEach {
                    when(it) {
                        is ServerConnectionEvent.DeviceConnected -> {
                            configureServices(it.connection.services)
                        }
                        is ServerConnectionEvent.DeviceDisconnected -> {
                            Timber.e("Server disconnected")
                        }
                    }
                }
                .collect()
```