### PR TITLE
Add close on disconnect parameter to ClientBleGatt

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/NativeClientBleAPI.kt
+++ b/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/NativeClientBleAPI.kt
@@ -68,7 +68,8 @@ import java.lang.reflect.Method
 class NativeClientBleAPI(
     private val gatt: BluetoothGatt,
     private val callback: ClientBleGattCallback,
-    override val autoConnect: Boolean
+    override val autoConnect: Boolean,
+    override val closeOnDisconnect: Boolean
 ) : GattClientAPI {
 
     override val event: SharedFlow<ClientGattEvent> = callback.event
@@ -174,6 +175,11 @@ class NativeClientBleAPI(
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     override fun disconnect() {
         gatt.disconnect()
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    override fun reconnect() {
+        gatt.connect()
     }
 
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)

--- a/client-api/src/main/java/no/nordicsemi/android/kotlin/ble/client/api/GattClientAPI.kt
+++ b/client-api/src/main/java/no/nordicsemi/android/kotlin/ble/client/api/GattClientAPI.kt
@@ -70,6 +70,11 @@ interface GattClientAPI {
     val autoConnect: Boolean
 
     /**
+     * Parameter indicating that Gatt should be closed on first disconnected event.
+     */
+    val closeOnDisconnect: Boolean
+
+    /**
      * Internal function for propagating events to [event] shared flow. For internal usage only.
      *
      * @param event equivalent of a callback method from [BluetoothGattCallback]
@@ -158,9 +163,14 @@ interface GattClientAPI {
     fun setPreferredPhy(txPhy: BleGattPhy, rxPhy: BleGattPhy, phyOption: PhyOption)
 
     /**
-     * Disconnect remote server.
+     * Disconnects from a peripheral.
      */
     fun disconnect()
+
+    /**
+     * Connects to a peripheral after disconnection. Works only if [BleGattConnectOptions.closeOnDisconnect] is set to false.
+     */
+    fun reconnect()
 
     /**
      * Clears services cache. It should invoke [BluetoothGattCallback.onServiceChanged] callback.

--- a/client-mock/src/main/java/no/nordicsemi/android/kotlin/ble/client/mock/BleMockGatt.kt
+++ b/client-mock/src/main/java/no/nordicsemi/android/kotlin/ble/client/mock/BleMockGatt.kt
@@ -63,7 +63,8 @@ class BleMockGatt(
     private val mockEngine: MockEngine,
     private val serverDevice: MockServerDevice,
     private val clientDevice: ClientDevice,
-    override val autoConnect: Boolean
+    override val autoConnect: Boolean,
+    override val closeOnDisconnect: Boolean
 ) : GattClientAPI {
 
     private val _event = MutableSharedFlow<ClientGattEvent>(extraBufferCapacity = 10, onBufferOverflow = BufferOverflow.DROP_OLDEST)
@@ -126,6 +127,10 @@ class BleMockGatt(
 
     override fun disconnect() {
         mockEngine.cancelConnection(serverDevice, clientDevice)
+    }
+
+    override fun reconnect() {
+        mockEngine.connect(clientDevice)
     }
 
     override fun clearServicesCache() {

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/callback/ClientBleGatt.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/callback/ClientBleGatt.kt
@@ -278,6 +278,19 @@ class ClientBleGatt(
     }
 
     /**
+     * Reconnects to the device if disconnected. Works only if [BleGattConnectOptions.closeOnDisconnect] is set to false.
+     */
+    fun reconnect() {
+        if (_connectionStateWithStatus.value?.state == GattConnectionState.STATE_CONNECTED) {
+            return
+        }
+        if (gatt.closeOnDisconnect) {
+            return
+        }
+        gatt.reconnect()
+    }
+
+    /**
      * Disconnects current device.
      */
     fun disconnect() {
@@ -310,7 +323,9 @@ class ClientBleGatt(
 
         if (connectionState == GattConnectionState.STATE_DISCONNECTED) {
             if (!status.isLinkLoss || !gatt.autoConnect) {
-                gatt.close()
+                if (gatt.closeOnDisconnect) {
+                    gatt.close()
+                }
             }
         }
     }

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/callback/ClientBleGattFactory.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/callback/ClientBleGattFactory.kt
@@ -110,7 +110,7 @@ internal object ClientBleGattFactory {
         logger: BleLogger,
     ): ClientBleGatt {
         val clientDevice = MockClientDevice()
-        val gatt = BleMockGatt(MockEngine, device, clientDevice, options.autoConnect)
+        val gatt = BleMockGatt(MockEngine, device, clientDevice, options.autoConnect, options.closeOnDisconnect)
         return ClientBleGatt(gatt, logger)
             .also { MockEngine.connectToServer(device, clientDevice, gatt, options) }
             .also { it.waitForConnection() }
@@ -149,6 +149,6 @@ internal object ClientBleGattFactory {
             device.connectGatt(context, options.autoConnect, gattCallback)
         }
 
-        return NativeClientBleAPI(gatt, gattCallback, options.autoConnect)
+        return NativeClientBleAPI(gatt, gattCallback, options.autoConnect, options.closeOnDisconnect)
     }
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/BleGattConnectOptions.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/BleGattConnectOptions.kt
@@ -36,10 +36,10 @@ package no.nordicsemi.android.kotlin.ble.core.data
  *
  * @property autoConnect Whether to directly connect to the remote device (false) or to automatically connect as soon as the remote device becomes available (true).
  * @property phy Only takes effect if [autoConnect] is set to false.
+ * @property closeOnDisconnect Closes GATT on first disconnect event. [ClientBleGatt] shouldn't be used after that.
  */
 data class BleGattConnectOptions(
-
     val autoConnect: Boolean = false,
-
-    val phy: BleGattPhy? = null
+    val phy: BleGattPhy? = null,
+    val closeOnDisconnect: Boolean = true
 )

--- a/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/MockEngine.kt
+++ b/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/MockEngine.kt
@@ -200,7 +200,7 @@ object MockEngine {
         }
     }
 
-    fun connect(device: ClientDevice, autoConnect: Boolean) {
+    fun connect(device: ClientDevice) {
         clientConnections[device]?.clientApi?.onEvent(
             ConnectionStateChanged(
                 BleGattConnectionStatus.SUCCESS,

--- a/server-mock/src/main/java/no/nordicsemi/android/kotlin/ble/server/mock/MockServerAPI.kt
+++ b/server-mock/src/main/java/no/nordicsemi/android/kotlin/ble/server/mock/MockServerAPI.kt
@@ -87,7 +87,7 @@ class MockServerAPI(
     }
 
     override fun connect(device: ClientDevice, autoConnect: Boolean) {
-        mockEngine.connect(device, autoConnect)
+        mockEngine.connect(device)
     }
 
     override fun readPhy(device: ClientDevice) {


### PR DESCRIPTION
Add possibility to reuse `ClientBleGatt` after device disconnects.

- Add `closeOnDisconnect ` parameter to `BleGattConnectOptions` indicating whether `gatt.close()` should be called after disconnection.
- Add `reconnect()` function to  `ClientBleGatt`.