### PR TITLE
Implement fixes for issues reported on Github

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2015, Nordic Semiconductor
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Kotlin-BLE-Library nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/BleAdvertiserLegacy.kt
+++ b/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/BleAdvertiserLegacy.kt
@@ -42,8 +42,8 @@ import androidx.annotation.RequiresPermission
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import no.nordicsemi.android.kotlin.ble.advertiser.callback.BleAdvertisingStatus
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.BleAdvertisingEvent
+import no.nordicsemi.android.kotlin.ble.advertiser.callback.BleAdvertisingStatus
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStarted
 import no.nordicsemi.android.kotlin.ble.advertiser.data.toLegacy
 import no.nordicsemi.android.kotlin.ble.advertiser.data.toNative

--- a/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/callback/BleAdvertisingSetCallback.kt
+++ b/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/callback/BleAdvertisingSetCallback.kt
@@ -73,14 +73,14 @@ internal class BleAdvertisingSetCallback(
      * Callback responsible for emitting event [OnAdvertisingSetStarted].
      */
     override fun onAdvertisingSetStarted(advertisingSet: AdvertisingSet?, txPower: Int, status: Int) {
-        onEvent(OnAdvertisingSetStarted(advertisingSet!!, txPower, BleAdvertisingStatus.create(status)))
+        onEvent(OnAdvertisingSetStarted(advertisingSet, txPower, BleAdvertisingStatus.create(status)))
     }
 
     /**
      * Callback responsible for emitting event [OnAdvertisingSetStopped].
      */
     override fun onAdvertisingSetStopped(advertisingSet: AdvertisingSet?) {
-        onEvent(OnAdvertisingSetStopped(advertisingSet!!))
+        onEvent(OnAdvertisingSetStopped(advertisingSet))
     }
 
     /**

--- a/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/callback/BleAdvertisingStatus.kt
+++ b/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/callback/BleAdvertisingStatus.kt
@@ -43,6 +43,12 @@ import android.bluetooth.le.AdvertisingSetCallback
 enum class BleAdvertisingStatus(internal val value: Int) {
 
     /**
+     * Some manufactures adds their custom codes. This value means that status code couldn't be
+     * parsed using standard values.
+     */
+    UNKNOWN(99),
+
+    /**
      * Failed to start advertising as the advertising is already started.
      *
      * @see [AdvertisingSetCallback.ADVERTISE_FAILED_ALREADY_STARTED]
@@ -86,8 +92,7 @@ enum class BleAdvertisingStatus(internal val value: Int) {
 
     companion object {
         fun create(value: Int): BleAdvertisingStatus {
-            return values().firstOrNull { it.value == value }
-                ?: throw IllegalStateException("Can't create status for value: $value")
+            return values().firstOrNull { it.value == value } ?: UNKNOWN
         }
     }
 }

--- a/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/data/Mapper.kt
+++ b/advertiser/src/main/java/no/nordicsemi/android/kotlin/ble/advertiser/data/Mapper.kt
@@ -65,9 +65,9 @@ internal fun BleAdvertisingSettings.toLegacy(): AdvertiseSettings {
 
 internal fun BleAdvertisingData.toNative(): AdvertiseData {
     val builder = AdvertiseData.Builder()
-    builder.setIncludeTxPowerLevel(includeTxPowerLever)
-    builder.setIncludeDeviceName(includeDeviceName)
-    builder.addServiceUuid(serviceUuid)
+    serviceUuid?.let { builder.addServiceUuid(it) }
+    includeDeviceName?.let { builder.setIncludeDeviceName(it) }
+    includeTxPowerLever?.let { builder.setIncludeTxPowerLevel(it) }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         serviceSolicitationUuid?.let { builder.addServiceSolicitationUuid(it) }
     }

--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/repository/BlinkyServer.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/repository/BlinkyServer.kt
@@ -43,7 +43,8 @@ class BlinkyServer @Inject constructor(
         val ledCharacteristic = ServerBleGattCharacteristicConfig(
             BlinkySpecifications.UUID_LED_CHAR,
             listOf(BleGattProperty.PROPERTY_READ, BleGattProperty.PROPERTY_WRITE),
-            listOf(BleGattPermission.PERMISSION_READ, BleGattPermission.PERMISSION_WRITE)
+            listOf(BleGattPermission.PERMISSION_READ, BleGattPermission.PERMISSION_WRITE),
+            initialValue = DataByteArray.from(0x01)
         )
 
         val buttonCharacteristic = ServerBleGattCharacteristicConfig(
@@ -107,7 +108,7 @@ class BlinkyServer @Inject constructor(
                         service.findCharacteristic(BlinkySpecifications.UUID_BUTTON_CHAR)!!
 
                     buttonState.onEach {
-                        buttonCharacteristic.setValue(it)
+                        buttonCharacteristic.setValueAndNotifyClient(it)
                     }.launchIn(this)
                 }
         }

--- a/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/ServerViewModel.kt
+++ b/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/ServerViewModel.kt
@@ -104,7 +104,8 @@ class ServerViewModel @Inject constructor(
             val ledCharacteristic = ServerBleGattCharacteristicConfig(
                 BlinkySpecifications.UUID_LED_CHAR,
                 listOf(BleGattProperty.PROPERTY_READ, BleGattProperty.PROPERTY_WRITE),
-                listOf(BleGattPermission.PERMISSION_READ, BleGattPermission.PERMISSION_WRITE)
+                listOf(BleGattPermission.PERMISSION_READ, BleGattPermission.PERMISSION_WRITE),
+                initialValue = DataByteArray.from(0x00)
             )
 
             //Define button characteristic
@@ -180,12 +181,12 @@ class ServerViewModel @Inject constructor(
         this.buttonCharacteristic = buttonCharacteristic
     }
 
-    fun onButtonPressedChanged(isButtonPressed: Boolean) {
+    fun onButtonPressedChanged(isButtonPressed: Boolean) = viewModelScope.launch {
         val value = if (isButtonPressed) {
             DataByteArray.from(0x01)
         } else {
             DataByteArray.from(0x00)
         }
-        buttonCharacteristic?.setValue(value)
+        buttonCharacteristic?.setValueAndNotifyClient(value)
     }
 }

--- a/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/ServerViewModel.kt
+++ b/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/ServerViewModel.kt
@@ -34,6 +34,7 @@ package no.nordicsemi.android.kotlin.ble.server
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.ParcelUuid
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -54,7 +55,9 @@ import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStar
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStopped
 import no.nordicsemi.android.kotlin.ble.core.advertiser.BleAdvertisingConfig
 import no.nordicsemi.android.kotlin.ble.core.advertiser.BleAdvertisingData
+import no.nordicsemi.android.kotlin.ble.core.advertiser.BleAdvertisingInterval
 import no.nordicsemi.android.kotlin.ble.core.advertiser.BleAdvertisingSettings
+import no.nordicsemi.android.kotlin.ble.core.advertiser.BleTxPowerLevel
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
 import no.nordicsemi.android.kotlin.ble.server.main.ServerBleGatt
@@ -105,7 +108,7 @@ class ServerViewModel @Inject constructor(
                 BlinkySpecifications.UUID_LED_CHAR,
                 listOf(BleGattProperty.PROPERTY_READ, BleGattProperty.PROPERTY_WRITE),
                 listOf(BleGattPermission.PERMISSION_READ, BleGattPermission.PERMISSION_WRITE),
-                initialValue = DataByteArray.from(0x00)
+                initialValue = DataByteArray.from(0x01)
             )
 
             //Define button characteristic
@@ -127,10 +130,13 @@ class ServerViewModel @Inject constructor(
             val advertiser = BleAdvertiser.create(context)
             val advertiserConfig = BleAdvertisingConfig(
                 settings = BleAdvertisingSettings(
-                    deviceName = "My Server" // Advertise a device name
+                    deviceName = "a", // Advertise a device name,
+                    legacyMode = true,
+                    scannable = true
                 ),
                 advertiseData = BleAdvertisingData(
-                    ParcelUuid(BlinkySpecifications.UUID_SERVICE_DEVICE) //Advertise main service uuid.
+                    ParcelUuid(BlinkySpecifications.UUID_SERVICE_DEVICE), //Advertise main service uuid.
+                    includeDeviceName = true,
                 )
             )
 
@@ -138,6 +144,7 @@ class ServerViewModel @Inject constructor(
                 advertiser.advertise(advertiserConfig) //Start advertising
                     .cancellable()
                     .catch { it.printStackTrace() }
+                    .onEach { Log.d("ADVERTISER", "New event: $it") }
                     .collect { //Observe advertiser lifecycle events
                         if (it is OnAdvertisingSetStarted) { //Handle advertising start event
                             _state.value = _state.value.copy(isAdvertising = true)

--- a/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/ClientBleGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/ClientBleGattCallback.kt
@@ -98,7 +98,7 @@ class ClientBleGattCallback: BluetoothGattCallback() {
     ) {
         characteristic?.let {
             val native = NativeBluetoothGattCharacteristic(it)
-            _event.tryEmit(CharacteristicChanged(native, DataByteArray(native.value)))
+            _event.tryEmit(CharacteristicChanged(native, native.value))
         }
     }
 
@@ -126,7 +126,7 @@ class ClientBleGattCallback: BluetoothGattCallback() {
     ) {
         characteristic?.let {
             val native = NativeBluetoothGattCharacteristic(characteristic)
-            _event.tryEmit(CharacteristicRead(native, DataByteArray(native.value), BleGattOperationStatus.create(status)))
+            _event.tryEmit(CharacteristicRead(native, native.value, BleGattOperationStatus.create(status)))
         }
     }
 
@@ -168,7 +168,7 @@ class ClientBleGattCallback: BluetoothGattCallback() {
     ) {
         descriptor?.let {
             val native = NativeBluetoothGattDescriptor(descriptor)
-            _event.tryEmit(DescriptorRead(native, DataByteArray(native.value), BleGattOperationStatus.create(status)))
+            _event.tryEmit(DescriptorRead(native, native.value, BleGattOperationStatus.create(status)))
         }
     }
 

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattCharacteristic.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattCharacteristic.kt
@@ -46,15 +46,16 @@ import no.nordicsemi.android.common.core.DataByteArray
 import no.nordicsemi.android.common.logger.BleLogger
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent.*
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI
-import no.nordicsemi.android.kotlin.ble.client.main.errors.GattOperationException
-import no.nordicsemi.android.kotlin.ble.client.main.errors.MissingPropertyException
-import no.nordicsemi.android.kotlin.ble.client.main.errors.NotificationDescriptorNotFoundException
+import no.nordicsemi.android.kotlin.ble.core.errors.DeviceDisconnectedException
+import no.nordicsemi.android.kotlin.ble.core.errors.GattOperationException
+import no.nordicsemi.android.kotlin.ble.core.errors.MissingPropertyException
+import no.nordicsemi.android.kotlin.ble.core.errors.NotificationDescriptorNotFoundException
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConsts
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
 import no.nordicsemi.android.kotlin.ble.core.mutex.MutexWrapper
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattCharacteristic
 import java.util.*
 import kotlin.coroutines.resume
@@ -74,7 +75,7 @@ private val DISABLE_NOTIFICATION_VALUE = DataByteArray(byteArrayOf(0x00, 0x00))
  * @property characteristic Identifier of a characteristic.
  * @property logger Logger class for displaying logs.
  * @property mutex Mutex for synchronising requests.
- * @property mtuProvider For providing MTU value established per connection.
+ * @property connectionProvider For providing MTU value established per connection.
  */
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 @SuppressLint("InlinedApi")
@@ -83,7 +84,7 @@ class ClientBleGattCharacteristic internal constructor(
     private val characteristic: IBluetoothGattCharacteristic,
     private val logger: BleLogger,
     private val mutex: MutexWrapper,
-    private val mtuProvider: MtuProvider,
+    private val connectionProvider: ConnectionProvider,
 ) {
 
     /**
@@ -115,10 +116,15 @@ class ClientBleGattCharacteristic internal constructor(
      * It is suspend function which suspends and waits for result. It will also suspend when other
      * request is already being executed.
      *
+     * @throws DeviceDisconnectedException when a BLE device is disconnected.
+     *
      * @return [Flow] which emits new bytes on notification.
      */
     @SuppressLint("MissingPermission")
     suspend fun getNotifications(): Flow<DataByteArray> {
+        if (!connectionProvider.isConnected) {
+            throw DeviceDisconnectedException()
+        }
         try {
             enableIndicationsOrNotifications()
         } catch (e: Exception) {
@@ -135,7 +141,7 @@ class ClientBleGattCharacteristic internal constructor(
         }
     }
 
-    val descriptors = characteristic.descriptors.map { ClientBleGattDescriptor(gatt, instanceId, it, logger, mutex, mtuProvider) }
+    val descriptors = characteristic.descriptors.map { ClientBleGattDescriptor(gatt, instanceId, it, logger, mutex, connectionProvider) }
 
     private var pendingReadEvent: ((CharacteristicRead) -> Unit)? = null
     private var pendingWriteEvent: ((CharacteristicWrite) -> Unit)? = null
@@ -187,12 +193,16 @@ class ClientBleGattCharacteristic internal constructor(
      *
      * @throws GattOperationException on GATT communication failure.
      * @throws MissingPropertyException when property defined by [writeType] is missing.
+     * @throws DeviceDisconnectedException when a BLE device is disconnected.
      *
      * @param value Bytes to write.
      * @param writeType Write type method.
      */
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     suspend fun write(value: DataByteArray, writeType: BleWriteType = BleWriteType.DEFAULT) {
+        if (!connectionProvider.isConnected) {
+            throw DeviceDisconnectedException()
+        }
         mutex.lock()
         val stacktrace = Exception() //Helper exception to display valid stacktrace.
         return suspendCoroutine { continuation ->
@@ -219,6 +229,7 @@ class ClientBleGattCharacteristic internal constructor(
      *
      * @throws GattOperationException on GATT communication failure.
      * @throws MissingPropertyException when property defined by [writeType] is missing.
+     * @throws DeviceDisconnectedException when a BLE device is disconnected.
      *
      * @param value Bytes to write.
      * @param writeType Write type method.
@@ -226,7 +237,7 @@ class ClientBleGattCharacteristic internal constructor(
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     suspend fun splitWrite(value: DataByteArray, writeType: BleWriteType = BleWriteType.DEFAULT) {
         logger.log(Log.DEBUG, "Split write to characteristic - start, uuid: $uuid, value: ${value}, type: $writeType")
-        value.split(mtuProvider.availableMtu(writeType)).forEach {
+        value.split(connectionProvider.availableMtu(writeType)).forEach {
             write(it, writeType)
         }
         logger.log(Log.DEBUG, "Split write to characteristic - end, uuid: $uuid")
@@ -257,11 +268,15 @@ class ClientBleGattCharacteristic internal constructor(
      *
      * @throws MissingPropertyException when [BleGattProperty.PROPERTY_READ] not found on a characteristic.
      * @throws GattOperationException on GATT communication failure.
+     * @throws DeviceDisconnectedException when a BLE device is disconnected.
      *
      * @return Read value.
      */
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     suspend fun read(): DataByteArray {
+        if (!connectionProvider.isConnected) {
+            throw DeviceDisconnectedException()
+        }
         mutex.lock()
         val stacktrace = Exception() //Helper exception to display valid stacktrace.
         return suspendCoroutine { continuation ->
@@ -327,6 +342,9 @@ class ClientBleGattCharacteristic internal constructor(
 
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private suspend fun disableNotifications() {
+        if (!connectionProvider.isConnected) {
+            throw DeviceDisconnectedException()
+        }
         logger.log(Log.DEBUG, "Disable notifications on characteristic - start, uuid: $uuid")
         return findDescriptor(BleGattConsts.NOTIFICATION_DESCRIPTOR)?.let { descriptor ->
             gatt.disableCharacteristicNotification(characteristic)

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattService.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattService.kt
@@ -35,7 +35,7 @@ import no.nordicsemi.android.common.logger.BleLogger
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI
 import no.nordicsemi.android.kotlin.ble.core.mutex.MutexWrapper
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattService
 import java.util.UUID
 
@@ -46,14 +46,14 @@ import java.util.UUID
  * @property service Identifier of a service.
  * @property logger Logger class for displaying logs.
  * @property mutex Mutex for synchronising requests.
- * @property mtuProvider For providing MTU value established per connection.
+ * @property connectionProvider For providing MTU value established per connection.
  */
 data class ClientBleGattService internal constructor(
     private val gatt: GattClientAPI,
     private val service: IBluetoothGattService,
     private val logger: BleLogger,
     private val mutex: MutexWrapper,
-    private val mtuProvider: MtuProvider
+    private val connectionProvider: ConnectionProvider
 ) {
 
     /**
@@ -63,7 +63,7 @@ data class ClientBleGattService internal constructor(
 
     @Suppress("MemberVisibilityCanBePrivate")
     val characteristics = service.characteristics.map {
-        ClientBleGattCharacteristic(gatt, it, logger, mutex, mtuProvider)
+        ClientBleGattCharacteristic(gatt, it, logger, mutex, connectionProvider)
     }
 
     /**

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattServices.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattServices.kt
@@ -35,7 +35,7 @@ import no.nordicsemi.android.common.logger.BleLogger
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI
 import no.nordicsemi.android.kotlin.ble.core.mutex.MutexWrapper
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattService
 import java.util.UUID
 
@@ -46,17 +46,17 @@ import java.util.UUID
  * @property androidGattServices Identifiers of a services.
  * @property logger Logger class for displaying logs.
  * @property mutex Mutex for synchronising requests.
- * @property mtuProvider For providing MTU value established per connection.
+ * @property connectionProvider For providing MTU value established per connection.
  */
 data class ClientBleGattServices internal constructor(
     private val gatt: GattClientAPI,
     private val androidGattServices: List<IBluetoothGattService>,
     private val logger: BleLogger,
     private val mutex: MutexWrapper,
-    private val mtuProvider: MtuProvider
+    private val connectionProvider: ConnectionProvider
 ) {
 
-    val services = androidGattServices.map { ClientBleGattService(gatt, it, logger, mutex, mtuProvider) }
+    val services = androidGattServices.map { ClientBleGattService(gatt, it, logger, mutex, connectionProvider) }
 
     /**
      * Finds service based on [uuid].

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/BleAdvertisingData.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/BleAdvertisingData.kt
@@ -51,9 +51,9 @@ import androidx.annotation.RequiresApi
  * @see [AdvertiseData](https://developer.android.com/reference/android/bluetooth/le/AdvertiseData)
  */
 data class BleAdvertisingData(
-    val serviceUuid: ParcelUuid,
-    val includeDeviceName: Boolean = true,
-    val includeTxPowerLever: Boolean = false,
+    val serviceUuid: ParcelUuid? = null,
+    val includeDeviceName: Boolean? = null,
+    val includeTxPowerLever: Boolean? = null,
     val manufacturerData: List<ManufacturerData> = emptyList(),
     val serviceData: List<ServiceData> = emptyList(),
 

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/BleAdvertisingInterval.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/BleAdvertisingInterval.kt
@@ -48,17 +48,17 @@ import androidx.annotation.RestrictTo
 enum class BleAdvertisingInterval {
 
     /**
-     * Perform Bluetooth LE advertising in low power mode.
+     * Perform high frequency, low latency advertising, around every 100ms.
      */
     INTERVAL_LOW,
 
     /**
-     * Perform Bluetooth LE advertising in balanced power mode.
+     * Advertise on medium frequency, around every 250ms.
      */
     INTERVAL_MEDIUM,
 
     /**
-     * Perform Bluetooth LE advertising in low latency, high power mode.
+     * Advertise on low frequency, around every 1000ms.
      */
     INTERVAL_HIGH;
 

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/GattConnectionStateWithStatus.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/GattConnectionStateWithStatus.kt
@@ -39,5 +39,19 @@ package no.nordicsemi.android.kotlin.ble.core.data
  */
 data class GattConnectionStateWithStatus(
     val state: GattConnectionState,
-    val status: BleGattConnectionStatus
-)
+    val status: BleGattConnectionStatus,
+) {
+
+    companion object {
+
+        val CONNECTED = GattConnectionStateWithStatus(
+            GattConnectionState.STATE_CONNECTED,
+            BleGattConnectionStatus.SUCCESS
+        )
+
+        val DISCONNECTED = GattConnectionStateWithStatus(
+            GattConnectionState.STATE_DISCONNECTED,
+            BleGattConnectionStatus.SUCCESS
+        )
+    }
+}

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/DeviceDisconnectedException.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/DeviceDisconnectedException.kt
@@ -1,0 +1,3 @@
+package no.nordicsemi.android.kotlin.ble.core.errors
+
+class DeviceDisconnectedException : GattException("Operation cannot be performed when device is not connected.")

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/GattException.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/GattException.kt
@@ -29,19 +29,14 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.client.main.errors
-
-import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
+package no.nordicsemi.android.kotlin.ble.core.errors
 
 /**
- * An exception indicating that the operation cannot be performed, because of a missing property
- * i.e. an attempt to read from a characteristic which doesn't have [BleGattProperty.PROPERTY_READ].
+ * Sealed class grouping GATT exceptions.
  *
- * @constructor
- * Creates exception instance.
- *
- * @param property A missing property which causes exception.
+ * @property message Display message describing a problem
  */
-class MissingPropertyException(property: BleGattProperty) : GattException(
-    message = "Operation cannot be performed because of the missing property: $property"
-)
+sealed class GattException(
+    override val message: String,
+    override val cause: Throwable? = null
+) : Exception()

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/GattOperationException.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/GattOperationException.kt
@@ -29,7 +29,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.client.main.errors
+package no.nordicsemi.android.kotlin.ble.core.errors
 
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus
 

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/MissingPropertyException.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/MissingPropertyException.kt
@@ -29,14 +29,19 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.client.main.errors
+package no.nordicsemi.android.kotlin.ble.core.errors
+
+import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
 
 /**
- * Sealed class grouping GATT exceptions.
+ * An exception indicating that the operation cannot be performed, because of a missing property
+ * i.e. an attempt to read from a characteristic which doesn't have [BleGattProperty.PROPERTY_READ].
  *
- * @property message Display message describing a problem
+ * @constructor
+ * Creates exception instance.
+ *
+ * @param property A missing property which causes exception.
  */
-sealed class GattException(
-    override val message: String,
-    override val cause: Throwable? = null
-) : Exception()
+class MissingPropertyException(property: BleGattProperty) : GattException(
+    message = "Operation cannot be performed because of the missing property: $property"
+)

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/NotificationDescriptorNotFoundException.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/errors/NotificationDescriptorNotFoundException.kt
@@ -29,7 +29,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.client.main.errors
+package no.nordicsemi.android.kotlin.ble.core.errors
 
 /**
  * Exception thrown during enabling/disabling notification/indications when no CCCD descriptor

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/mutex/SharedMutexWrapper.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/mutex/SharedMutexWrapper.kt
@@ -1,0 +1,3 @@
+package no.nordicsemi.android.kotlin.ble.core.mutex
+
+val SharedMutexWrapper = MutexWrapper()

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/provider/ConnectionProvider.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/provider/ConnectionProvider.kt
@@ -33,20 +33,39 @@ package no.nordicsemi.android.kotlin.ble.core.provider
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.mapNotNull
+import no.nordicsemi.android.kotlin.ble.core.data.BleGattConnectionStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
+import no.nordicsemi.android.kotlin.ble.core.data.GattConnectionState
+import no.nordicsemi.android.kotlin.ble.core.data.GattConnectionStateWithStatus
 import no.nordicsemi.android.kotlin.ble.core.data.Mtu
 
 /**
- * Provides an MTU value.
+ * Provides a connection parameters.
  *
- * MTU value is shared between many components. To avoid propagating MTU value changed event to
- * all of the components, the [MtuProvider] is shared instead in constructor and value is updated
- * using it's field.
+ * MTU and connection state is shared between many components. To avoid propagating those values changes to
+ * all of the components, the [ConnectionProvider] is shared in a constructor.
  *
  */
-class MtuProvider {
+class ConnectionProvider {
 
     private val _mtu = MutableStateFlow(Mtu.min)
+
+    /**
+     * Returns last observed [GattConnectionState] with it's corresponding status [BleGattConnectionStatus].
+     */
+    val connectionStateWithStatus = MutableStateFlow<GattConnectionStateWithStatus?>(null)
+
+    /**
+     * Returns last [GattConnectionState] without it's status.
+     */
+    val connectionState = connectionStateWithStatus.mapNotNull { it?.state }
+
+    /**
+     * Returns whether a device is connected.
+     */
+    val isConnected
+        get() = connectionStateWithStatus.value?.state == GattConnectionState.STATE_CONNECTED
 
     /**
      * Most recent MTU value.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/IBluetoothGattCharacteristic.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/IBluetoothGattCharacteristic.kt
@@ -32,6 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattCharacteristic
+import no.nordicsemi.android.common.core.DataByteArray
 import java.util.UUID
 
 /**
@@ -71,7 +72,7 @@ interface IBluetoothGattCharacteristic {
     /**
      * [ByteArray] value of this characteristic.
      */
-    var value: ByteArray
+    var value: DataByteArray
 
     /**
      * List of descriptors of this characteristic.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/IBluetoothGattDescriptor.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/IBluetoothGattDescriptor.kt
@@ -32,6 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattDescriptor
+import no.nordicsemi.android.common.core.DataByteArray
 import java.util.UUID
 
 /**
@@ -56,7 +57,7 @@ interface IBluetoothGattDescriptor {
     /**
      * [ByteArray] value of this descriptor.
      */
-    var value: ByteArray
+    var value: DataByteArray
 
     /**
      * Parent characteristic of this descriptor. There is a circular dependency between

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/MockBluetoothGattCharacteristic.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/MockBluetoothGattCharacteristic.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
+import no.nordicsemi.android.common.core.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
 import java.util.UUID
 
@@ -46,17 +47,17 @@ data class MockBluetoothGattCharacteristic private constructor(
     override val permissions: Int,
     override val properties: Int,
     override val instanceId: Int, //TODO check if instance id should change during copy()
-    override var value: ByteArray,
+    override var value: DataByteArray,
     private var _descriptors: List<IBluetoothGattDescriptor>,
     override var writeType: Int,
 ) : IBluetoothGattCharacteristic {
 
-    constructor(uuid: UUID, permissions: Int, properties: Int) : this(
+    constructor(uuid: UUID, permissions: Int, properties: Int, value: DataByteArray) : this(
         uuid,
         permissions,
         properties,
         InstanceIdGenerator.nextValue(),
-        byteArrayOf(),
+        value,
         emptyList(),
         BleWriteType.DEFAULT.value
     )
@@ -84,7 +85,7 @@ data class MockBluetoothGattCharacteristic private constructor(
         if (permissions != other.permissions) return false
         if (properties != other.properties) return false
         if (instanceId != other.instanceId) return false
-        if (!value.contentEquals(other.value)) return false
+        if (value != other.value) return false
         if (_descriptors != other._descriptors) return false
         if (descriptors != other.descriptors) return false
 
@@ -96,7 +97,7 @@ data class MockBluetoothGattCharacteristic private constructor(
         result = 31 * result + permissions
         result = 31 * result + properties
         result = 31 * result + instanceId
-        result = 31 * result + value.contentHashCode()
+        result = 31 * result + value.hashCode()
         result = 31 * result + _descriptors.hashCode()
         result = 31 * result + descriptors.hashCode()
         return result

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/MockBluetoothGattDescriptor.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/MockBluetoothGattDescriptor.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
+import no.nordicsemi.android.common.core.DataByteArray
 import java.util.UUID
 
 /**
@@ -44,7 +45,7 @@ data class MockBluetoothGattDescriptor(
     override val uuid: UUID,
     override val permissions: Int,
     override val characteristic: IBluetoothGattCharacteristic,
-    override var value: ByteArray = byteArrayOf()
+    override var value: DataByteArray = DataByteArray()
 ) : IBluetoothGattDescriptor {
 
     override fun equals(other: Any?): Boolean {
@@ -56,7 +57,7 @@ data class MockBluetoothGattDescriptor(
         if (uuid != other.uuid) return false
         if (permissions != other.permissions) return false
         if (characteristic != other.characteristic) return false
-        if (!value.contentEquals(other.value)) return false
+        if (value != other.value) return false
 
         return true
     }
@@ -64,7 +65,7 @@ data class MockBluetoothGattDescriptor(
     override fun hashCode(): Int {
         var result = uuid.hashCode()
         result = 31 * result + permissions
-        result = 31 * result + value.contentHashCode()
+        result = 31 * result + value.hashCode()
         return result
     }
 

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattCharacteristic.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattCharacteristic.kt
@@ -32,6 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattCharacteristic
+import no.nordicsemi.android.common.core.DataByteArray
 import no.nordicsemi.android.common.core.toDisplayString
 import java.util.UUID
 
@@ -55,10 +56,10 @@ data class NativeBluetoothGattCharacteristic(
         set(value) {
             characteristic.writeType = value
         }
-    override var value: ByteArray
-        get() = characteristic.value ?: byteArrayOf()
+    override var value: DataByteArray
+        get() = DataByteArray(characteristic.value ?: byteArrayOf())
         set(value) {
-            characteristic.value = value
+            characteristic.value = value.value
         }
     override val descriptors: List<IBluetoothGattDescriptor>
         get() = characteristic.descriptors.map { NativeBluetoothGattDescriptor(it) }
@@ -71,7 +72,7 @@ data class NativeBluetoothGattCharacteristic(
             .append("permissions : $permissions, ")
             .append("properties : $properties, ")
             .append("writeType : $writeType, ")
-            .append("value : ${value.toDisplayString()}, ")
+            .append("value : $value, ")
             .append("descriptors : $descriptors ")
             .append("}")
             .toString()

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattDescriptor.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattDescriptor.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattDescriptor
-import no.nordicsemi.android.common.core.toDisplayString
+import no.nordicsemi.android.common.core.DataByteArray
 import java.util.UUID
 
 /**
@@ -48,10 +48,10 @@ data class NativeBluetoothGattDescriptor(
     override val permissions: Int
         get() = descriptor.permissions
 
-    override var value: ByteArray
-        get() = descriptor.value ?: byteArrayOf()
+    override var value: DataByteArray
+        get() = DataByteArray(descriptor.value ?: byteArrayOf())
         set(value) {
-            descriptor.value = value
+            descriptor.value = value.value
         }
 
     override val characteristic: IBluetoothGattCharacteristic =
@@ -62,7 +62,7 @@ data class NativeBluetoothGattDescriptor(
             .append("{ ")
             .append("uuid : $uuid, ")
             .append("permissions : $permissions, ")
-            .append("value : ${value.toDisplayString()}, ")
+            .append("value : $value, ")
             .append("}")
             .toString()
     }

--- a/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/MockEngine.kt
+++ b/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/MockEngine.kt
@@ -198,6 +198,7 @@ object MockEngine {
         if (connection.enabledNotification[characteristic.uuid] == true) {
             connection.clientApi.onEvent(CharacteristicChanged(characteristic, value))
         }
+        connection.serverApi.onEvent(NotificationSent(device, BleGattOperationStatus.GATT_SUCCESS))
     }
 
     fun connect(device: ClientDevice) {

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/BluetoothGattServiceFactory.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/BluetoothGattServiceFactory.kt
@@ -36,6 +36,7 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattService
 import android.os.Build
+import no.nordicsemi.android.common.core.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConsts
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
@@ -120,6 +121,7 @@ internal object BluetoothGattServiceFactory {
             // handler is used in connectGatt().
             clone = characteristic
         }
+        clone.value = characteristic.value
         return clone
     }
 
@@ -134,14 +136,15 @@ internal object BluetoothGattServiceFactory {
             val characteristic = MockBluetoothGattCharacteristic(
                 it.uuid,
                 BleGattPermission.toInt(it.permissions),
-                BleGattProperty.toInt(it.properties)
+                BleGattProperty.toInt(it.properties),
+                it.initialValue ?: DataByteArray()
             )
 
             it.descriptorConfigs.forEach {
                 val descriptor = MockBluetoothGattDescriptor(
                     it.uuid,
                     BleGattPermission.toInt(it.permissions),
-                    characteristic
+                    characteristic,
                 )
                 characteristic.addDescriptor(descriptor)
             }

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristic.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristic.kt
@@ -89,7 +89,11 @@ class ServerBleGattCharacteristic internal constructor(
 
     private var onNotificationSent: ((NotificationSent) -> Unit)? = null
 
-    private val _value = ValueFlow.create()
+    private val _value = ValueFlow.create().apply {
+        if (characteristic.value != DataByteArray()) { //Don't emit empty value
+            this.tryEmit(characteristic.value)
+        }
+    }
 
     /**
      * The last value stored on this characteristic.
@@ -141,7 +145,7 @@ class ServerBleGattCharacteristic internal constructor(
      *
      * @param value Bytes to set.
      */
-    suspend fun setAndNotify(value: DataByteArray) {
+    suspend fun setValueAndNotifyClient(value: DataByteArray) {
         val isNotification = properties.contains(BleGattProperty.PROPERTY_NOTIFY)
         val isIndication = properties.contains(BleGattProperty.PROPERTY_INDICATE)
 

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristic.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristic.kt
@@ -40,12 +40,17 @@ import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
+import no.nordicsemi.android.kotlin.ble.core.errors.GattOperationException
+import no.nordicsemi.android.kotlin.ble.core.errors.MissingPropertyException
 import no.nordicsemi.android.kotlin.ble.core.event.ValueFlow
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattCharacteristic
 import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
 import no.nordicsemi.android.kotlin.ble.server.api.ServerGattEvent.*
 import java.util.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 /**
  * A helper class which handles operation which can happen on a GATT characteristic on a server
@@ -56,7 +61,7 @@ import java.util.*
  * @property server [GattServerAPI] for communication with the client device.
  * @property device A client device to which this characteristic belongs.
  * @property characteristic Identifier of a characteristic.
- * @property mtuProvider For providing mtu value established per connection.
+ * @property connectionProvider For providing mtu value established per connection.
  */
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 @SuppressLint("MissingPermission")
@@ -64,7 +69,7 @@ class ServerBleGattCharacteristic internal constructor(
     private val server: GattServerAPI,
     private val device: ClientDevice,
     private val characteristic: IBluetoothGattCharacteristic,
-    private val mtuProvider: MtuProvider
+    private val connectionProvider: ConnectionProvider
 ) {
 
     /**
@@ -81,6 +86,8 @@ class ServerBleGattCharacteristic internal constructor(
      * Temporary value used during reliable write operation.
      */
     private var transactionalValue = DataByteArray()
+
+    private var onNotificationSent: ((NotificationSent) -> Unit)? = null
 
     private val _value = ValueFlow.create()
 
@@ -102,7 +109,7 @@ class ServerBleGattCharacteristic internal constructor(
         get() = BleGattProperty.createProperties(characteristic.properties)
 
     val descriptors = characteristic.descriptors.map {
-        ServerBleGattDescriptor(server, instanceId, it, mtuProvider)
+        ServerBleGattDescriptor(server, instanceId, it, connectionProvider)
     }
 
     /**
@@ -122,17 +129,40 @@ class ServerBleGattCharacteristic internal constructor(
      * @param value Bytes to set.
      */
     fun setValue(value: DataByteArray) {
-        // only notify once when the value changes
-        //todo think about improving this
-//        if (value.contentEquals(_value.value)) return
         _value.tryEmit(value)
-        characteristic.value = value.value
+        characteristic.value = value
+    }
 
+    /**
+     * Sets value for this characteristic and notify the client.
+     *
+     * @throws MissingPropertyException If a notification property is not set for this characteristic.
+     * @throws GattOperationException If sending notification fails.
+     *
+     * @param value Bytes to set.
+     */
+    suspend fun setAndNotify(value: DataByteArray) {
         val isNotification = properties.contains(BleGattProperty.PROPERTY_NOTIFY)
         val isIndication = properties.contains(BleGattProperty.PROPERTY_INDICATE)
 
         if (isNotification || isIndication) {
-            server.notifyCharacteristicChanged(device, characteristic, isIndication, value)
+            val stacktrace = Exception() //Helper exception to display valid stacktrace.
+            return suspendCoroutine { continuation ->
+                onNotificationSent = {
+                    onNotificationSent = null
+                    if (it.status.isSuccess) {
+                        setValue(value)
+                        continuation.resume(Unit)
+                    } else {
+                        continuation.resumeWithException(GattOperationException(it.status, stacktrace))
+                    }
+                }
+
+                server.notifyCharacteristicChanged(device, characteristic, isIndication, value)
+            }
+
+        } else {
+            throw MissingPropertyException(BleGattProperty.PROPERTY_NOTIFY)
         }
     }
 
@@ -206,6 +236,7 @@ class ServerBleGattCharacteristic internal constructor(
     }
 
     private fun onNotificationSent(event: NotificationSent) {
+        onNotificationSent?.invoke(event)
     }
 
     /**
@@ -238,7 +269,7 @@ class ServerBleGattCharacteristic internal constructor(
 
     /**
      * Handles read request. It gets value stored in [_value] field and tries to send it. If the
-     * size of [DataByteArray] is bigger than mtu value provided by [mtuProvider] then byte array
+     * size of [DataByteArray] is bigger than mtu value provided by [connectionProvider] then byte array
      * is send in consecutive chunks.
      *
      * @param event A read request event.
@@ -247,7 +278,7 @@ class ServerBleGattCharacteristic internal constructor(
         val status = BleGattOperationStatus.GATT_SUCCESS
         val offset = event.offset
         val value = _value.value
-        val data = value.getChunk(offset, mtuProvider.mtu.value)
+        val data = value.getChunk(offset, connectionProvider.mtu.value)
         server.sendResponse(event.device, event.requestId, status.value, event.offset, data)
     }
 }

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattDescriptor.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattDescriptor.kt
@@ -39,7 +39,7 @@ import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
 import no.nordicsemi.android.kotlin.ble.core.event.ValueFlow
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattDescriptor
 import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
 import no.nordicsemi.android.kotlin.ble.server.api.ServerGattEvent.*
@@ -54,7 +54,7 @@ import java.util.UUID
  * @property server [GattServerAPI] for communication with the client device.
  * @property characteristicInstanceId Instance id of a parent characteristic.
  * @property descriptor Identifier of a descriptor.
- * @property mtuProvider For providing mtu value established per connection.
+ * @property connectionProvider For providing mtu value established per connection.
  */
 @Suppress("unused")
 @SuppressLint("MissingPermission")
@@ -62,7 +62,7 @@ class ServerBleGattDescriptor internal constructor(
     private val server: GattServerAPI,
     private val characteristicInstanceId: Int,
     private val descriptor: IBluetoothGattDescriptor,
-    private val mtuProvider: MtuProvider
+    private val connectionProvider: ConnectionProvider
 ) {
 
     /**
@@ -166,7 +166,7 @@ class ServerBleGattDescriptor internal constructor(
 
     /**
      * Handles read request. It gets value stored in [_value] field and tries to send it. If the
-     * size of [DataByteArray] is bigger than mtu value provided by [mtuProvider] then byte array
+     * size of [DataByteArray] is bigger than mtu value provided by [connectionProvider] then byte array
      * is send in consecutive chunks.
      *
      * @param event A read request event.
@@ -174,7 +174,7 @@ class ServerBleGattDescriptor internal constructor(
     private fun onDescriptorReadRequest(event: DescriptorReadRequest) {
         val status = BleGattOperationStatus.GATT_SUCCESS
         val offset = event.offset
-        val data = _value.value.getChunk(offset, mtuProvider.mtu.value)
+        val data = _value.value.getChunk(offset, connectionProvider.mtu.value)
         server.sendResponse(event.device, event.requestId, status.value, event.offset, data)
     }
 }

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattDescriptor.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattDescriptor.kt
@@ -77,7 +77,11 @@ class ServerBleGattDescriptor internal constructor(
         get() = BleGattPermission.createPermissions(descriptor.permissions)
 
     private var transactionalValue = DataByteArray()
-    private val _value = ValueFlow.create()
+    private val _value = ValueFlow.create().apply {
+        if (descriptor.value != DataByteArray()) { //Don't emit empty value
+            this.tryEmit(descriptor.value)
+        }
+    }
 
     /**
      * The last value stored on this descriptor.

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattService.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattService.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.server.main.service
 
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattService
 import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
 import no.nordicsemi.android.kotlin.ble.server.api.ServerGattEvent
@@ -44,14 +44,14 @@ import java.util.UUID
  * @property server [GattServerAPI] for communication with a client devices.
  * @property device A client device.
  * @property service Identifier of a service.
- * @property mtuProvider For providing mtu value established per connection.
+ * @property connectionProvider For providing mtu value established per connection.
  */
 @Suppress("MemberVisibilityCanBePrivate")
 data class ServerBleGattService internal constructor(
     private val server: GattServerAPI,
     private val device: ClientDevice,
     private val service: IBluetoothGattService,
-    private val mtuProvider: MtuProvider
+    private val connectionProvider: ConnectionProvider
 ) {
 
     /**
@@ -63,7 +63,7 @@ data class ServerBleGattService internal constructor(
      * All characteristics of a service.
      */
     val characteristics = service.characteristics.map {
-        ServerBleGattCharacteristic(server, device, it, mtuProvider)
+        ServerBleGattCharacteristic(server, device, it, connectionProvider)
     }
 
     /**

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBluetoothGattConnection.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBluetoothGattConnection.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.server.main.service
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy
 import no.nordicsemi.android.kotlin.ble.core.data.PhyOption
-import no.nordicsemi.android.kotlin.ble.core.provider.MtuProvider
+import no.nordicsemi.android.kotlin.ble.core.provider.ConnectionProvider
 import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
 
 /**
@@ -43,16 +43,16 @@ import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
  * @property device A client device
  * @property server A server API instance unique per server. It is shared between all connected devices.
  * @property services Cloned services separate for this connection.
- * @property mtuProvider MTU provider for this connection.
+ * @property connectionProvider MTU provider for this connection.
  * @property txPhy Transmitter PHY value.
  * @property rxPhy Receiver PHY value.
  */
 @Suppress("unused")
 data class ServerBluetoothGattConnection internal constructor(
-    private val device: ClientDevice,
+    val device: ClientDevice,
     private val server: GattServerAPI,
     val services: ServerBleGattServices,
-    val mtuProvider: MtuProvider,
+    val connectionProvider: ConnectionProvider,
     val txPhy: BleGattPhy? = null,
     val rxPhy: BleGattPhy? = null
 ) {

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -63,17 +63,18 @@ dependencies {
 
     kaptTest(libs.hilt.compiler)
 
-    testImplementation(libs.hilt.android.testing)
-    testImplementation(libs.androidx.test.rules)
-    testImplementation(libs.junit4)
     testImplementation(libs.test.mockk)
+    testImplementation(libs.junit4)
+    testImplementation(libs.kotlin.junit)
     testImplementation(libs.androidx.test.ext)
+    testImplementation(libs.androidx.test.rules)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.test.slf4j.simple)
     testImplementation(libs.test.robolectric)
-    testImplementation(libs.kotlin.junit)
+    testImplementation(libs.hilt.android.testing)
 
     androidTestImplementation(libs.junit4)
+    androidTestImplementation(libs.kotlin.junit)
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.kotlinx.coroutines.test)

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/ExampleInstrumentedTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/ExampleInstrumentedTest.kt
@@ -49,6 +49,8 @@ import java.util.UUID
 class ExampleInstrumentedTest {
 
     // Change values before using
+    private val service: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    private val char: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
     private val address = TestAddressProvider.address
     private val address2 = TestAddressProvider.auxiliaryAddress
 
@@ -57,28 +59,13 @@ class ExampleInstrumentedTest {
     val rules: GrantPermissionRule = GrantPermissionRule.grant("android.permission.BLUETOOTH_CONNECT")
 
     @Test
-    fun testRssi() = runTest {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val gatt = ClientBleGatt.connect(context, address)
-        val gatt2 = ClientBleGatt.connect(context, address2)
-        val mutex = Mutex()
-
-        // This one passes when using a mutex
-        repeat(10) {
-            val jobs = listOf(
-                launch { mutex.withLock { gatt.readRssi() } },
-                launch { mutex.withLock { gatt2.readRssi() } }
-            )
-            jobs.forEach { it.join() }
-        }
-
-        // This one gets stuck when no mutex is used
-        repeat(10) {
-            val jobs = listOf(
-                launch { gatt.readRssi() },
-                launch { gatt2.readRssi() }
-            )
-            jobs.forEach { it.join() }
-        }
+    fun testExample() = runTest {
+        ClientBleGatt
+            .connect(InstrumentationRegistry.getInstrumentation().targetContext, address)
+            .discoverServices()
+            .findService(service)!!
+            .findCharacteristic(char)!!
+            .read()
+            .let { Assert.assertTrue(it.size >= 0) }
     }
 }

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/ExampleInstrumentedTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/ExampleInstrumentedTest.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runTest
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
+import no.nordicsemi.android.kotlin.ble.test.utils.TestAddressProvider
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -48,25 +49,12 @@ import java.util.UUID
 class ExampleInstrumentedTest {
 
     // Change values before using
-    private val service: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
-    private val char: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
-    private val address = "F6:1B:1A:66:27:57"
-    private val address2 = "CA:CC:95:E9:72:2B"
+    private val address = TestAddressProvider.address
+    private val address2 = TestAddressProvider.auxiliaryAddress
 
     @JvmField
     @Rule
     val rules: GrantPermissionRule = GrantPermissionRule.grant("android.permission.BLUETOOTH_CONNECT")
-
-    @Test
-    fun testExample() = runTest {
-        ClientBleGatt
-            .connect(InstrumentationRegistry.getInstrumentation().targetContext, address)
-            .discoverServices()
-            .findService(service)!!
-            .findCharacteristic(char)!!
-            .read()
-            .let { Assert.assertTrue(it.size >= 0) }
-    }
 
     @Test
     fun testRssi() = runTest {
@@ -74,8 +62,6 @@ class ExampleInstrumentedTest {
         val gatt = ClientBleGatt.connect(context, address)
         val gatt2 = ClientBleGatt.connect(context, address2)
         val mutex = Mutex()
-
-        println("AAA")
 
         // This one passes when using a mutex
         repeat(10) {
@@ -86,8 +72,6 @@ class ExampleInstrumentedTest {
             jobs.forEach { it.join() }
         }
 
-        println("BBB")
-
         // This one gets stuck when no mutex is used
         repeat(10) {
             val jobs = listOf(
@@ -96,7 +80,5 @@ class ExampleInstrumentedTest {
             )
             jobs.forEach { it.join() }
         }
-
-        println("CCC")
     }
 }

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/GetNotificationsStuckTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/GetNotificationsStuckTest.kt
@@ -1,0 +1,36 @@
+package no.nordicsemi.android.kotlin.ble.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
+import no.nordicsemi.android.kotlin.ble.core.errors.DeviceDisconnectedException
+import no.nordicsemi.android.kotlin.ble.test.utils.BlinkySpecifications
+import no.nordicsemi.android.kotlin.ble.test.utils.TestAddressProvider
+import org.junit.Test
+import org.junit.Assert
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GetNotificationsStuckTest {
+
+    val service = BlinkySpecifications.UUID_SERVICE_DEVICE
+    val char = BlinkySpecifications.UUID_BUTTON_CHAR
+
+    private val address = TestAddressProvider.address
+
+    @Test
+    fun whenGetNotificationsAfterDisconnectShouldThrow() = runTest {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val gatt = ClientBleGatt.connect(context, address)
+        val services = gatt.discoverServices()
+        val not = services.findService(service)?.findCharacteristic(char)!!
+        gatt.disconnect()           // Simulate a device disconnection
+        Assert.assertThrows(DeviceDisconnectedException::class.java) {
+            runBlocking {
+                not.getNotifications()     //Issue: stuck here forever
+            }
+        }
+    }
+}

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/ReadFromDisconnectedDeviceTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/ReadFromDisconnectedDeviceTest.kt
@@ -1,0 +1,36 @@
+package no.nordicsemi.android.kotlin.ble.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
+import no.nordicsemi.android.kotlin.ble.core.errors.DeviceDisconnectedException
+import no.nordicsemi.android.kotlin.ble.test.utils.BlinkySpecifications
+import no.nordicsemi.android.kotlin.ble.test.utils.TestAddressProvider
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReadFromDisconnectedDeviceTest {
+
+    val service = BlinkySpecifications.UUID_SERVICE_DEVICE
+    val char = BlinkySpecifications.UUID_LED_CHAR
+
+    private val address = TestAddressProvider.address
+
+    @Test
+    fun whenReadAfterDisconnectShouldThrow() = runTest {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val gatt = ClientBleGatt.connect(context, address)
+        val services = gatt.discoverServices()
+        val char = services.findService(service)?.findCharacteristic(char)
+        gatt.disconnect()          // Simulate a device disconnection
+        Assert.assertThrows(DeviceDisconnectedException::class.java) {
+            runBlocking {
+                char?.read()!!     //Issue: stuck here forever
+            }
+        }
+    }
+}

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/SimultaneousRssiStuckTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/SimultaneousRssiStuckTest.kt
@@ -1,0 +1,45 @@
+package no.nordicsemi.android.kotlin.ble.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
+import no.nordicsemi.android.kotlin.ble.test.utils.TestAddressProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SimultaneousRssiStuckTest {
+
+    private val address = TestAddressProvider.address
+    private val address2 = TestAddressProvider.auxiliaryAddress
+
+    @Test
+    fun whenReadRssiWithoutMutexShouldWork() = runTest {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val gatt = ClientBleGatt.connect(context, address)
+        val gatt2 = ClientBleGatt.connect(context, address2)
+        val mutex = Mutex()
+
+        // This one passes when using a mutex
+        repeat(10) {
+            val jobs = listOf(
+                launch { mutex.withLock { gatt.readRssi() } },
+                launch { mutex.withLock { gatt2.readRssi() } }
+            )
+            jobs.forEach { it.join() }
+        }
+
+        //Issue: This one gets stuck when no mutex is used
+        repeat(10) {
+            val jobs = listOf(
+                launch { gatt.readRssi() },
+                launch { gatt2.readRssi() }
+            )
+            jobs.forEach { it.join() }
+        }
+    }
+}

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/utils/BlinkySpecifications.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/utils/BlinkySpecifications.kt
@@ -1,0 +1,14 @@
+package no.nordicsemi.android.kotlin.ble.test.utils
+
+import java.util.UUID
+
+object BlinkySpecifications {
+    /** Nordic Blinky Service UUID. */
+    val UUID_SERVICE_DEVICE: UUID = UUID.fromString("00001523-1212-efde-1523-785feabcd123")
+
+    /** LED characteristic UUID. */
+    val UUID_LED_CHAR: UUID = UUID.fromString("00001525-1212-efde-1523-785feabcd123")
+
+    /** BUTTON characteristic UUID. */
+    val UUID_BUTTON_CHAR: UUID = UUID.fromString("00001524-1212-efde-1523-785feabcd123")
+}

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/utils/TestAddressProvider.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/utils/TestAddressProvider.kt
@@ -1,0 +1,7 @@
+package no.nordicsemi.android.kotlin.ble.test.utils
+
+object TestAddressProvider {
+
+    val address = "F6:1B:1A:66:27:57"
+    val auxiliaryAddress = "CA:CC:95:E9:72:2B"
+}

--- a/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/ReliableWriteTest.kt
+++ b/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/ReliableWriteTest.kt
@@ -41,7 +41,6 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -49,7 +48,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import no.nordicsemi.android.common.core.ApplicationScope
 import no.nordicsemi.android.common.core.DataByteArray
 import no.nordicsemi.android.common.logger.DefaultBleLogger
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
@@ -97,6 +95,8 @@ class ReliableWriteTest {
     @Inject
     lateinit var server: ReliableWriteServer
 
+    val scope = CoroutineScope(UnconfinedTestDispatcher())
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -111,9 +111,6 @@ class ReliableWriteTest {
     @Before
     fun before() {
         runBlocking {
-            mockkStatic("no.nordicsemi.android.common.core.ApplicationScopeKt")
-            every { ApplicationScope } returns CoroutineScope(UnconfinedTestDispatcher())
-
             server.start(context, serverDevice)
         }
     }
@@ -130,7 +127,7 @@ class ReliableWriteTest {
             GattConnectionState.STATE_CONNECTED,
             BleGattConnectionStatus.SUCCESS
         )
-        val client = ClientBleGatt.connect(context, serverDevice)
+        val client = ClientBleGatt.connect(context, serverDevice, scope = scope)
 
         assertEquals(connectedState, client.connectionStateWithStatus.value)
     }
@@ -141,7 +138,7 @@ class ReliableWriteTest {
             GattConnectionState.STATE_DISCONNECTED,
             BleGattConnectionStatus.SUCCESS
         )
-        val client = ClientBleGatt.connect(context, serverDevice)
+        val client = ClientBleGatt.connect(context, serverDevice, scope = scope)
 
         server.stopServer()
 
@@ -150,7 +147,7 @@ class ReliableWriteTest {
 
     @Test
     fun `when reliable aborted should return previous value`() = runTest {
-        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice)
+        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice, scope = scope)
         val services = client.discoverServices()
         val theService = services.findService(RELIABLE_WRITE_SERVICE)!!
         val firstCharacteristic = theService.findCharacteristic(FIRST_CHARACTERISTIC)!!
@@ -170,7 +167,7 @@ class ReliableWriteTest {
 
     @Test
     fun `when reliable aborted should return previous value on each characteristic`() = runTest {
-        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice)
+        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice, scope = scope)
         val services = client.discoverServices()
         val theService = services.findService(RELIABLE_WRITE_SERVICE)!!
         val firstCharacteristic = theService.findCharacteristic(FIRST_CHARACTERISTIC)!!
@@ -194,7 +191,7 @@ class ReliableWriteTest {
 
     @Test
     fun `when reliable executed should return new value`() = runTest {
-        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice)
+        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice, scope = scope)
         val services = client.discoverServices()
         val theService = services.findService(RELIABLE_WRITE_SERVICE)!!
         val firstCharacteristic = theService.findCharacteristic(FIRST_CHARACTERISTIC)!!
@@ -215,7 +212,7 @@ class ReliableWriteTest {
 
     @Test
     fun `when reliable executed should return new value on each characteristic`() = runTest {
-        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice)
+        val client: ClientBleGatt = ClientBleGatt.connect(context, serverDevice, scope = scope)
 
         val services = client.discoverServices()
         val theService = services.findService(RELIABLE_WRITE_SERVICE)!!


### PR DESCRIPTION
- Fix #44: Make client device field public in server connection.
- Fix #42: ServerBleGatt.create should have a timeout
- Fix #29: ServerBleGattCharacteristic does not wait for a BluetoothGattServerCallback.onNotificationSent
- Fix #48: Add license
- Fix #31: Initial value of a server characteristic is not set in tests
- Fix #34: Stuck Reads when disconnected
- Fix #33: ApplicationScope's dispatcher can't be changed in tests
- Fix #35: Concurrency issues when reading rssi
- Fix #39: Advertising fails to enable in the Blinky App
- Fix #30: Initial value of a server characteristic is not set
