### PR TITLE
connectionScope for #44

### DIFF
--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBluetoothGattConnection.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBluetoothGattConnection.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.server.main.service
 
+import kotlinx.coroutines.CoroutineScope
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy
 import no.nordicsemi.android.kotlin.ble.core.data.PhyOption
@@ -51,6 +52,7 @@ import no.nordicsemi.android.kotlin.ble.server.api.GattServerAPI
 data class ServerBluetoothGattConnection internal constructor(
     val device: ClientDevice,
     private val server: GattServerAPI,
+    val connectionScope: CoroutineScope,
     val services: ServerBleGattServices,
     val connectionProvider: ConnectionProvider,
     val txPhy: BleGattPhy? = null,


### PR DESCRIPTION
A nicer version for resource handling. If you need to clean up resources per connection, use:

```
connection.connectionScope.launch {
  try {
    awaitCancellation()
  } catch (_: CancellationException) {
    cleanup()
  }
}
```

Any subscriptions to flows to be pushed via setValue() can also be attached to `connectionScope`.

```
connection.connectionScope.launch {
  otherFlow.collect {
    characteristic.setValue(it)
  }
}
```