### PR TITLE
Fix IllegalArgumentException

### DIFF
--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleGattPrimaryPhy.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleGattPrimaryPhy.kt
@@ -57,9 +57,8 @@ enum class BleGattPrimaryPhy(val value: Int) {
     PHY_LE_CODED(BluetoothDevice.PHY_LE_CODED);
 
     companion object {
-        fun create(value: Int): BleGattPrimaryPhy {
+        fun createOrNull(value: Int): BleGattPrimaryPhy? {
             return values().firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException("Cannot create BleGattPrimaryPhy for value: $value")
         }
     }
 }

--- a/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/data/Mappers.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/data/Mappers.kt
@@ -73,7 +73,7 @@ internal fun ScanResult.toDomain(): BleScanResultData {
             this.timestampNanos,
             this.scanRecord?.toDomain(),
             getAdvertisingSid(this),
-            BleGattPrimaryPhy.create(this.primaryPhy),
+            BleGattPrimaryPhy.createOrNull(this.primaryPhy),
             getSecondaryPhy(this),
             getTxPower(this),
             getPeriodicAdvertisingInterval(this),


### PR DESCRIPTION
Fatal Exception: java.lang.IllegalArgumentException
Cannot create BleGattPrimaryPhy for value: 0
no.nordicsemi.android.kotlin.ble.core.scanner.BleGattPrimaryPhy$Companion.create (BleGattPrimaryPhy.java:294)
no.nordicsemi.android.kotlin.ble.scanner.data.MappersKt.toDomain (Mappers.kt:294)
no.nordicsemi.android.kotlin.ble.scanner.MapperKt.toScanItem (Mapper.kt:294)