### PR TITLE
Making UUID filter optional in Scanner View

### DIFF
--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
@@ -106,14 +106,18 @@ internal class ScannerViewModel @Inject constructor(
     // scanner is not visible. Scanner state stops scanning when it is not observed.
     // .stateIn(viewModelScope, SharingStarted.Lazily, ScanningState.Loading)
     private fun List<BleScanResults>.applyFilters(config: DevicesScanFilter) =
-            filter { !config.filterUuidRequired || it.lastScanResult?.scanRecord?.serviceUuids?.contains(uuid) == true }
+            filter {
+                uuid == null ||
+                config.filterUuidRequired == false ||
+                it.lastScanResult?.scanRecord?.serviceUuids?.contains(uuid) == true
+            }
            .filter { !config.filterNearbyOnly || it.highestRssi >= FILTER_RSSI }
            .filter { !config.filterWithNames || it.device.hasName }
 
     fun setFilterUuid(uuid: ParcelUuid?) {
         this.uuid = uuid
         if (uuid == null) {
-            filterConfig.value = filterConfig.value.copy(filterUuidRequired = false)
+            filterConfig.value = filterConfig.value.copy(filterUuidRequired = null)
         }
     }
 

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/repository/DevicesScanFilter.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/repository/DevicesScanFilter.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.ui.scanner.repository
 
 internal data class DevicesScanFilter(
-    val filterUuidRequired: Boolean,
+    val filterUuidRequired: Boolean?,
     val filterNearbyOnly: Boolean,
     val filterWithNames: Boolean
 )

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/FilterView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/FilterView.kt
@@ -60,7 +60,7 @@ internal fun FilterView(
         horizontalArrangement = Arrangement.Start,
         modifier = modifier,
     ) {
-        config.filterUuidRequired.let {
+        config.filterUuidRequired?.let {
             ElevatedFilterChip(
                 selected = !it,
                 onClick = { onChanged(config.copy(filterUuidRequired = !it)) },


### PR DESCRIPTION
I copied the filed from https://github.com/NordicPlayground/Android-Common-Libraries/blob/1.5.2/uiscanner/src/main/java/no/nordicsemi/android/common/ui/scanner/main/viewmodel/ScannerViewModel.kt where `filterUuidRequired` was optional. Migrating to BLEK made it not-optional.