### PR TITLE
Displaying advertised name instead of the cached one

### DIFF
--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleScanResults.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleScanResults.kt
@@ -53,4 +53,7 @@ data class BleScanResults(
 
     @IgnoredOnParcel
     val lastScanResult = scanResult.lastOrNull()
+
+    @IgnoredOnParcel
+    val advertisedName: String? = scanResult.firstNotNullOfOrNull { it.scanRecord?.deviceName }
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleScanResults.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleScanResults.kt
@@ -40,7 +40,7 @@ import no.nordicsemi.android.kotlin.ble.core.ServerDevice
  * Class containing all scan results grouped with an advertising device.
  *
  * @property device [ServerDevice] which may be connectable
- * @property data List of scan results ([BleScanResultData]) captured during scanning.
+ * @property scanResult List of scan results ([BleScanResultData]) captured during scanning.
  */
 @Parcelize
 data class BleScanResults(

--- a/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/BleScanner.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/BleScanner.kt
@@ -48,10 +48,10 @@ import no.nordicsemi.android.kotlin.ble.core.MockServerDevice
 import no.nordicsemi.android.kotlin.ble.core.RealServerDevice
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleScanFilter
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleScanResult
+import no.nordicsemi.android.kotlin.ble.core.scanner.BleScannerSettings
 import no.nordicsemi.android.kotlin.ble.mock.MockDevices
 import no.nordicsemi.android.kotlin.ble.scanner.errors.ScanFailedError
 import no.nordicsemi.android.kotlin.ble.scanner.errors.ScanningFailedException
-import no.nordicsemi.android.kotlin.ble.core.scanner.BleScannerSettings
 import no.nordicsemi.android.kotlin.ble.scanner.settings.toNative
 
 /**

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerScreen.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerScreen.kt
@@ -49,7 +49,7 @@ fun ScannerScreen(
     cancellable: Boolean = true,
     onResult: (ScannerScreenResult) -> Unit,
     deviceItem: @Composable (BleScanResults) -> Unit = {
-        DeviceListItem(it.device.name, it.device.address)
+        DeviceListItem(it.advertisedName, it.device.address)
     }
 ) {
     var isScanning by rememberSaveable { mutableStateOf(false) }

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerView.kt
@@ -65,7 +65,7 @@ fun ScannerView(
     onScanningStateChanged: (Boolean) -> Unit = {},
     onResult: (BleScanResults) -> Unit,
     deviceItem: @Composable (BleScanResults) -> Unit = {
-        DeviceListItem(it.device.name, it.device.address)
+        DeviceListItem(it.advertisedName, it.device.address)
     },
     showFilter: Boolean = true
 ) {

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
@@ -108,7 +108,7 @@ internal class ScannerViewModel @Inject constructor(
     private fun List<BleScanResults>.applyFilters(config: DevicesScanFilter) =
             filter { !config.filterUuidRequired || it.lastScanResult?.scanRecord?.serviceUuids?.contains(uuid) == true }
            .filter { !config.filterNearbyOnly || it.highestRssi >= FILTER_RSSI }
-           .filter { !config.filterWithNames || it.device.hasName }
+           .filter { !config.filterWithNames || it.advertisedName?.isNotEmpty() == true }
 
     fun setFilterUuid(uuid: ParcelUuid?) {
         this.uuid = uuid


### PR DESCRIPTION
This PR adds the following improvements:
1. Advertised name is used on the Scanner views instead of device name (cached value from `BluetoothDevice.name`)
2. New `advertisedName` computed property added to `BleScanResults`

This PR fixes the following bug:
*In nRF DFU after a succesful DFU the device name gets cleared (`refresh()` called). When trying to scan the device for the second time, the scan ends with nothing, as the device gets filtered out due to "lack of name". However, the name from the advertising packet is not null and is ignored.*