### PR TITLE
Fixed displaying bonded devices which have no advertising data

### DIFF
--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerScreen.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerScreen.kt
@@ -49,7 +49,7 @@ fun ScannerScreen(
     cancellable: Boolean = true,
     onResult: (ScannerScreenResult) -> Unit,
     deviceItem: @Composable (BleScanResults) -> Unit = {
-        DeviceListItem(it.advertisedName, it.device.address)
+        DeviceListItem(it.advertisedName ?: it.device.name, it.device.address)
     }
 ) {
     var isScanning by rememberSaveable { mutableStateOf(false) }

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerView.kt
@@ -65,7 +65,7 @@ fun ScannerView(
     onScanningStateChanged: (Boolean) -> Unit = {},
     onResult: (BleScanResults) -> Unit,
     deviceItem: @Composable (BleScanResults) -> Unit = {
-        DeviceListItem(it.advertisedName, it.device.address)
+        DeviceListItem(it.advertisedName ?: it.device.name, it.device.address)
     },
     showFilter: Boolean = true
 ) {

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
@@ -112,7 +112,7 @@ internal class ScannerViewModel @Inject constructor(
                 it.lastScanResult?.scanRecord?.serviceUuids?.contains(uuid) == true
             }
            .filter { !config.filterNearbyOnly || it.highestRssi >= FILTER_RSSI }
-           .filter { !config.filterWithNames || it.advertisedName?.isNotEmpty() == true }
+           .filter { !config.filterWithNames || it.device.hasName || it.advertisedName?.isNotEmpty() == true }
 
     fun setFilterUuid(uuid: ParcelUuid?) {
         this.uuid = uuid


### PR DESCRIPTION
My last PR #71 forced using the name from the advertising data. However, bonded devices which do not advertise don't have such, therefore were filtered out when Name filter was selected. This PR fixes that by checking both names. The UI displays the advertised name with higher priority.