### PR TITLE
Fixed printing "No name" when the device name is empty

### DIFF
--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/DeviceListItem.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/DeviceListItem.kt
@@ -72,7 +72,7 @@ fun DeviceListItem(
                 .fillMaxWidth()
                 .weight(1f)
         ) {
-            name?.let { name ->
+            name?.takeIf { it.isNotEmpty() }?.let { name ->
                 Text(
                     text = name,
                     style = MaterialTheme.typography.titleMedium


### PR DESCRIPTION
### Before

On ScannerView devices with no name were shown without any name. The default name, I guess, is "", not null.

### After

Both "" and null are shown as "_No name_".