### PR TITLE
UI Scanner migrated to Material 3 version 1.2.0-alpha11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,6 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.secrets) apply false
-    alias(libs.plugins.protobuf) apply false
     alias(libs.plugins.nordic.application) apply false
     alias(libs.plugins.nordic.application.compose) apply false
     alias(libs.plugins.nordic.library) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ slf4j = "2.0.9"
 robolectric = "4.11.1"
 
 nordic-log = "2.3.0"
-nordic-common = "1.8.5"
+nordic-common = "1.9.0"
 nordicPlugins = "1.9.13"
 dokkaPlugin = "1.9.10"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-accompanist = "0.32.0"
 androidDesugarJdkLibs = "2.0.4"
 androidGradlePlugin = "8.1.4"
 androidxActivity = "1.8.1"
@@ -28,11 +27,8 @@ androidxTestRules = "1.5.0"
 androidxTracing = "1.1.0"
 androidxUiAutomator = "2.2.0"
 androidxWork = "2.8.1"
-coil = "2.5.0"
-firebaseBom = "32.6.0"
 hilt = "2.48.1"
 hiltExt = "1.1.0"
-jacoco = "0.8.7"
 junit4 = "4.13.2"
 kotlin = "1.9.20"
 kotlinxCoroutines = "1.7.3"
@@ -40,51 +36,18 @@ kotlinxDatetime = "0.4.1"
 kotlinxSerializationJson = "1.6.1"
 ksp = "1.9.10-1.0.13"
 lint = "31.1.4"
-memfault-cloud = "2.0.5"
-okhttp = "4.12.0"
-protobuf = "3.25.1"
-protobufPlugin = "0.9.4"
 publishPlugin = "1.2.1"
-retrofit = "2.9.0"
-retrofitKotlinxSerializationJson = "1.0.0"
-room = "2.6.0"
-secrets = "2.0.1"
-turbine = "1.0.0"
-markdown = "0.3.6"
-wirePlugin = "4.9.2"
-timber = "5.0.1"
-chart = "3.1.0"
 leakcanary = "2.12"
 mockk = "1.13.8"
 slf4j = "2.0.9"
 robolectric = "4.11.1"
-skydovesBallon = "1.6.2"
-moshiKotlin = "1.15.0"
-moshiAdapters = "1.15.0"
-moshiConverter = "2.9.0"
-moshi = "1.15.0"
-moshiKotlinCodegen = "1.15.0"
 
-nordic-blek = "1.0.8"
-nordic-ble = "2.7.2"
-nordic-dfu = "2.3.2"
 nordic-log = "2.3.0"
-nordic-mcumgr = "1.8.1"
-nordic-scanner = "1.6.0"
 nordic-common = "1.8.5"
-nordic-memfault = "1.0.2"
 nordicPlugins = "1.9.13"
 dokkaPlugin = "1.9.10"
-googleServicesPlugins = "4.4.0"
-firebaseCrashlyticsPlugins = "2.9.9"
 
 [libraries]
-accompanist-flowlayout = { group = "com.google.accompanist", name = "accompanist-flowlayout", version.ref = "accompanist" }
-accompanist-swiperefresh = { group = "com.google.accompanist", name = "accompanist-swiperefresh", version.ref = "accompanist" }
-accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
-accompanist-pager = { group = "com.google.accompanist", name = "accompanist-pager", version.ref = "accompanist" }
-accompanist-pagerindicators = { group = "com.google.accompanist", name = "accompanist-pager-indicators", version.ref = "accompanist" }
-accompanist-placeholder = { group = "com.google.accompanist", name = "accompanist-placeholder-material", version.ref = "accompanist" }
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
@@ -138,13 +101,6 @@ androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiaut
 androidx-tracing-ktx = {group = "androidx.tracing", name="tracing-ktx", version.ref = "androidxTracing" }
 androidx-work-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidxWork" }
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidxWork" }
-coil-kt = { group = "io.coil-kt", name = "coil", version.ref = "coil"}
-coil-kt-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil"}
-coil-kt-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil"}
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom"}
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
-firebase-database = { group = "com.google.firebase", name = "firebase-database-ktx" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-ext-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExt" }
 hilt-ext-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExt" }
@@ -159,39 +115,14 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 lint-api = { group = "com.android.tools.lint", name = "lint-api", version.ref = "lint" }
-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
-protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
-protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
-turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
-retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
-markdown = { group = "com.github.jeziellago", name = "compose-markdown", version.ref = "markdown" }
-memfault-cloud = { group = "com.memfault.cloud", name = "cloud-android", version.ref = "memfault-cloud" }
-timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
-chart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "chart" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
 test-slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 test-mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 test-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-skydoves-ballon = {group = "com.github.skydoves", name = "balloon-compose", version.ref = "skydovesBallon"}
-moshi-kotlin = {group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin"}
-moshi-adapters = {group = "com.squareup.moshi", name = "moshi-adapters", version.ref = "moshiAdapters"}
-moshi-converter = {group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "moshiConverter"}
-moshi = {group = "com.squareup.moshi", name = "moshi", version.ref = "moshi"}
-moshi-kotlin-codegen = {group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen"}
 
 # Nordic
-nordic-ble-ktx = { group = "no.nordicsemi.android", name = "ble-ktx", version.ref = "nordic-ble" }
-nordic-ble-common = { group = "no.nordicsemi.android", name = "ble-common", version.ref = "nordic-ble" }
-nordic-dfu = { group = "no.nordicsemi.android", name = "dfu", version.ref = "nordic-dfu" }
-nordic-mcumgr-core = { group = "no.nordicsemi.android", name = "mcumgr-core", version.ref = "nordic-mcumgr" }
-nordic-mcumgr-ble = { group = "no.nordicsemi.android", name = "mcumgr-ble", version.ref = "nordic-mcumgr" }
 nordic-log = { group = "no.nordicsemi.android", name = "log", version.ref = "nordic-log" }
 nordic-log-timber = { group = "no.nordicsemi.android", name = "log-timber", version.ref = "nordic-log" }
-nordic-scanner = { group = "no.nordicsemi.android.support.v18", name = "scanner", version.ref = "nordic-scanner" }
 nordic-core = { group = "no.nordicsemi.android.common", name = "core", version.ref = "nordic-common" }
 nordic-theme = { group = "no.nordicsemi.android.common", name = "theme", version.ref = "nordic-common" }
 nordic-analytics = { group = "no.nordicsemi.android.common", name = "analytics", version.ref = "nordic-common" }
@@ -201,16 +132,6 @@ nordic-logger = { group = "no.nordicsemi.android.common", name = "logger", versi
 nordic-permissions-nfc = { group = "no.nordicsemi.android.common", name = "permissions-nfc", version.ref = "nordic-common" }
 nordic-permissions-ble = { group = "no.nordicsemi.android.common", name = "permissions-ble", version.ref = "nordic-common" }
 nordic-permissions-internet = { group = "no.nordicsemi.android.common", name = "permissions-internet", version.ref = "nordic-common" }
-nordic-memfault = { group = "no.nordicsemi.android", name = "memfault", version.ref = "nordic-memfault" }
-
-# BleK
-nordic-blek-client = { group = "no.nordicsemi.android.kotlin.ble", name = "client", version.ref = "nordic-blek" }
-nordic-blek-server = { group = "no.nordicsemi.android.kotlin.ble", name = "server", version.ref = "nordic-blek" }
-nordic-blek-profile = { group = "no.nordicsemi.android.kotlin.ble", name = "profile", version.ref = "nordic-blek" }
-nordic-blek-core = { group = "no.nordicsemi.android.kotlin.ble", name = "core", version.ref = "nordic-blek" }
-nordic-blek-scanner = { group = "no.nordicsemi.android.kotlin.ble", name = "scanner", version.ref = "nordic-blek" }
-nordic-blek-advertiser = { group = "no.nordicsemi.android.kotlin.ble", name = "advertiser", version.ref = "nordic-blek" }
-nordic-blek-uiscanner = { group = "no.nordicsemi.android.kotlin.ble", name = "uiscanner", version.ref = "nordic-blek" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -236,9 +157,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
-protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 publish = { id = "com.gradle.plugin-publish", version.ref = "publishPlugin" }
-wire = { id = "com.squareup.wire", version.ref = "wirePlugin" }
-google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugins" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugins" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ leakcanary = "2.12"
 mockk = "1.13.8"
 slf4j = "2.0.9"
 robolectric = "4.11.1"
+material3 = "1.2.0-alpha11"
+material = "1.6.0-beta01"
 
 nordic-log = "2.3.0"
 nordic-common = "1.9.0"
@@ -56,9 +58,9 @@ androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-mac
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
-androidx-compose-material = { group = "androidx.compose.material", name = "material" }
+androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "material"  }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3"  }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material3-windowSizeClass = {group = "androidx.compose.material3", name = "material3-window-size-class" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }

--- a/uiscanner/build.gradle.kts
+++ b/uiscanner/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
     implementation(libs.nordic.theme)
     implementation(libs.nordic.core)
     implementation(libs.nordic.permissions.ble)
-    implementation(libs.accompanist.flowlayout)
 
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.compose.material.iconsExtended)

--- a/uiscanner/build.gradle.kts
+++ b/uiscanner/build.gradle.kts
@@ -64,6 +64,6 @@ dependencies {
     implementation(libs.nordic.core)
     implementation(libs.nordic.permissions.ble)
 
-    implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
 }

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/ScannerAppBar.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/ScannerAppBar.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.ui.scanner.view
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -49,7 +49,7 @@ import no.nordicsemi.android.common.theme.view.NordicAppBar
 fun ScannerAppBar(
     text: String,
     showProgress: Boolean = false,
-    backButtonIcon: ImageVector = Icons.Default.ArrowBack,
+    backButtonIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowBack,
     onNavigationButtonClick: (() -> Unit)? = null,
 ) {
     NordicAppBar(

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/FilterView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/FilterView.kt
@@ -31,13 +31,19 @@
 
 package no.nordicsemi.android.kotlin.ble.ui.scanner.view.internal
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.Done
-import androidx.compose.material.icons.filled.Label
 import androidx.compose.material.icons.filled.Widgets
 import androidx.compose.material.icons.filled.Wifi
-import androidx.compose.material3.*
+import androidx.compose.material3.ElevatedFilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,7 +54,6 @@ import no.nordicsemi.android.common.theme.NordicTheme
 import no.nordicsemi.android.kotlin.ble.ui.scanner.R
 import no.nordicsemi.android.kotlin.ble.ui.scanner.repository.DevicesScanFilter
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun FilterView(
     config: DevicesScanFilter,
@@ -100,7 +105,7 @@ internal fun FilterView(
                     if (it) {
                         Icon(Icons.Default.Done, contentDescription = "")
                     } else {
-                        Icon(Icons.Default.Label, contentDescription = "")
+                        Icon(Icons.AutoMirrored.Filled.Label, contentDescription = "")
                     }
                 },
             )
@@ -112,14 +117,26 @@ internal fun FilterView(
 @Composable
 private fun FilterViewPreview() {
     NordicTheme {
-        FilterView(
-            config = DevicesScanFilter(
-                filterUuidRequired = true,
-                filterNearbyOnly = true,
-                filterWithNames = true,
-            ),
-            onChanged = {},
-            modifier = Modifier.fillMaxWidth(),
-        )
+        Column {
+            FilterView(
+                config = DevicesScanFilter(
+                    filterUuidRequired = true,
+                    filterNearbyOnly = true,
+                    filterWithNames = true,
+                ),
+                onChanged = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            FilterView(
+                config = DevicesScanFilter(
+                    filterUuidRequired = false,
+                    filterNearbyOnly = false,
+                    filterWithNames = false,
+                ),
+                onChanged = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/ScanEmptyView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/ScanEmptyView.kt
@@ -37,7 +37,7 @@ import android.provider.Settings
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BluetoothSearching
+import androidx.compose.material.icons.automirrored.filled.BluetoothSearching
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,7 +61,7 @@ internal fun ScanEmptyView(
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp),
-        imageVector = Icons.Default.BluetoothSearching,
+        imageVector = Icons.AutoMirrored.Filled.BluetoothSearching,
         title = stringResource(id = R.string.no_device_guide_title),
         hint = stringResource(id = R.string.no_device_guide_info) + if (requireLocation) {
             "\n\n" + stringResource(id = R.string.no_device_guide_location_info)

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/ScanErrorView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/ScanErrorView.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.ui.scanner.view.internal
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BluetoothSearching
+import androidx.compose.material.icons.automirrored.filled.BluetoothSearching
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -52,7 +52,7 @@ internal fun ScanErrorView(
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp),
-        imageVector = Icons.Default.BluetoothSearching,
+        imageVector = Icons.AutoMirrored.Filled.BluetoothSearching,
         title = stringResource(id = R.string.scanner_error),
         hint = stringResource(id = R.string.scan_failed, error),
     )


### PR DESCRIPTION
Material 3 version 1.2.0-alpha11 adds PullToRefresh component.

This PR also removes unused dependencies from internal toml file.