### PR TITLE
Fix Missing Notifications

### DIFF
--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattCharacteristic.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattCharacteristic.kt
@@ -138,7 +138,7 @@ class ClientBleGattCharacteristic internal constructor(
 
         return _notifications
             .apply { if (bufferSize > 0) buffer(bufferSize, bufferOverflow) }
-            .onStart { enableIndicationsOrNotifications() }
+            .also { enableIndicationsOrNotifications() }
             .onEach { log(it) }
             .onCompletion { disableNotificationsIfConnected() }
     }


### PR DESCRIPTION
Enabling notifications on the `onStart` block will cause loss of notifications since `onStart` is called too late. Moved the enabling to an also block instead.