### PR TITLE
Dependencies updated

### DIFF
--- a/advertiser/build.gradle.kts
+++ b/advertiser/build.gradle.kts
@@ -62,5 +62,4 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.core)
-    api(libs.nordic.core)
 }

--- a/app_client/build.gradle.kts
+++ b/app_client/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     implementation(libs.nordic.permissions.ble)
     implementation(libs.nordic.logger)
 
+    // New logging system is using SFL4J and Timber.
+    implementation(libs.slf4j.timber)
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.compose.material3)

--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/HiltApplication.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/HiltApplication.kt
@@ -34,7 +34,10 @@ package no.nordicsemi.android.kotlin.ble.app.client
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import no.nordicsemi.android.kotlin.ble.app.client.repository.BlinkyServer
+import timber.log.Timber
+import timber.log.Timber.DebugTree
 import javax.inject.Inject
+
 
 @HiltAndroidApp
 class HiltApplication : Application() {
@@ -44,6 +47,9 @@ class HiltApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Plant a Timber DebugTree to collect logs from BLEK.
+        Timber.plant(DebugTree())
 
         server.start(this)
     }

--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/repository/BlinkyServer.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/repository/BlinkyServer.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.advertiser.BleAdvertiser
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStarted
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStopped

--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/screen/repository/BlinkyButtonParser.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/screen/repository/BlinkyButtonParser.kt
@@ -31,7 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.app.client.screen.repository
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 object BlinkyButtonParser {
 

--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/screen/repository/BlinkyLedParser.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/screen/repository/BlinkyLedParser.kt
@@ -31,7 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.app.client.screen.repository
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 object BlinkyLedParser {
 

--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/screen/viewmodel/BlinkyViewModel.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/screen/viewmodel/BlinkyViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.common.navigation.Navigator
 import no.nordicsemi.android.common.navigation.viewmodel.SimpleNavigationViewModel
 import no.nordicsemi.android.kotlin.ble.app.client.BlinkyDestinationId

--- a/app_server/build.gradle.kts
+++ b/app_server/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation(libs.nordic.navigation)
     implementation(libs.nordic.permissions.ble)
 
+    // New logging system is using SFL4J and Timber.
+    implementation(libs.slf4j.timber)
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.compose.material3)

--- a/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/HiltApplication.kt
+++ b/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/HiltApplication.kt
@@ -33,6 +33,14 @@ package no.nordicsemi.android.kotlin.ble.server
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 @HiltAndroidApp
-class HiltApplication : Application()
+class HiltApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // Plant a Timber DebugTree to collect logs from BLEK.
+        Timber.plant(Timber.DebugTree())
+    }
+}

--- a/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/ServerViewModel.kt
+++ b/app_server/src/main/java/no/nordicsemi/android/kotlin/ble/server/ServerViewModel.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.advertiser.BleAdvertiser
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStarted
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStopped

--- a/client-android/build.gradle.kts
+++ b/client-android/build.gradle.kts
@@ -62,5 +62,4 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/ClientBleGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/ClientBleGattCallback.kt
@@ -36,7 +36,7 @@ import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import androidx.annotation.RestrictTo
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent.*
 import no.nordicsemi.android.kotlin.ble.client.api.ClientMutexHandleCallback

--- a/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/NativeClientBleAPI.kt
+++ b/client-android/src/main/java/no/nordicsemi/android/kotlin/ble/client/real/NativeClientBleAPI.kt
@@ -40,7 +40,7 @@ import androidx.annotation.IntRange
 import androidx.annotation.RequiresPermission
 import androidx.annotation.RestrictTo
 import kotlinx.coroutines.flow.SharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent.*

--- a/client-api/build.gradle.kts
+++ b/client-api/build.gradle.kts
@@ -61,5 +61,4 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/client-api/src/main/java/no/nordicsemi/android/kotlin/ble/client/api/ClientGattEvent.kt
+++ b/client-api/src/main/java/no/nordicsemi/android/kotlin/ble/client/api/ClientGattEvent.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.client.api
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConnectionStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy

--- a/client-api/src/main/java/no/nordicsemi/android/kotlin/ble/client/api/GattClientAPI.kt
+++ b/client-api/src/main/java/no/nordicsemi/android/kotlin/ble/client/api/GattClientAPI.kt
@@ -36,7 +36,7 @@ import android.bluetooth.BluetoothGattCallback
 import androidx.annotation.IntRange
 import androidx.annotation.RestrictTo
 import kotlinx.coroutines.flow.SharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.ServerDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConnectOptions
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConnectionPriority

--- a/client-mock/build.gradle.kts
+++ b/client-mock/build.gradle.kts
@@ -63,5 +63,4 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/client-mock/src/main/java/no/nordicsemi/android/kotlin/ble/client/mock/BleMockGatt.kt
+++ b/client-mock/src/main/java/no/nordicsemi/android/kotlin/ble/client/mock/BleMockGatt.kt
@@ -33,7 +33,7 @@ package no.nordicsemi.android.kotlin.ble.client.mock
 
 import androidx.annotation.IntRange
 import kotlinx.coroutines.flow.SharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.ClientMutexHandleCallback
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     api(project(":core"))
-    api(libs.nordic.logger)
+    implementation(libs.slf4j)
 
     implementation(project(":client-api"))
     implementation(project(":mock"))
@@ -68,5 +68,4 @@ dependencies {
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.core.ktx)
-    api(libs.nordic.core)
 }

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/bonding/BondingBroadcastReceiver.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/bonding/BondingBroadcastReceiver.kt
@@ -93,7 +93,7 @@ class BondingBroadcastReceiver : BroadcastReceiver() {
                     context.applicationContext,
                     instance,
                     IntentFilter(ACTION_BOND_STATE_CHANGED),
-                    ContextCompat.RECEIVER_NOT_EXPORTED
+                    ContextCompat.RECEIVER_EXPORTED
                 )
             }
         }

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattService.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattService.kt
@@ -31,7 +31,6 @@
 
 package no.nordicsemi.android.kotlin.ble.client.main.service
 
-import no.nordicsemi.android.common.logger.BleLogger
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI
 import no.nordicsemi.android.kotlin.ble.core.mutex.MutexWrapper
@@ -51,7 +50,6 @@ import java.util.UUID
 data class ClientBleGattService internal constructor(
     private val gatt: GattClientAPI,
     private val service: IBluetoothGattService,
-    private val logger: BleLogger,
     private val mutex: MutexWrapper,
     private val connectionProvider: ConnectionProvider
 ) {
@@ -63,7 +61,7 @@ data class ClientBleGattService internal constructor(
 
     @Suppress("MemberVisibilityCanBePrivate")
     val characteristics = service.characteristics.map {
-        ClientBleGattCharacteristic(gatt, it, logger, mutex, connectionProvider)
+        ClientBleGattCharacteristic(gatt, it, mutex, connectionProvider)
     }
 
     /**

--- a/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattServices.kt
+++ b/client/src/main/java/no/nordicsemi/android/kotlin/ble/client/main/service/ClientBleGattServices.kt
@@ -31,7 +31,6 @@
 
 package no.nordicsemi.android.kotlin.ble.client.main.service
 
-import no.nordicsemi.android.common.logger.BleLogger
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI
 import no.nordicsemi.android.kotlin.ble.core.mutex.MutexWrapper
@@ -51,12 +50,11 @@ import java.util.UUID
 data class ClientBleGattServices internal constructor(
     private val gatt: GattClientAPI,
     private val androidGattServices: List<IBluetoothGattService>,
-    private val logger: BleLogger,
     private val mutex: MutexWrapper,
     private val connectionProvider: ConnectionProvider
 ) {
 
-    val services = androidGattServices.map { ClientBleGattService(gatt, it, logger, mutex, connectionProvider) }
+    val services = androidGattServices.map { ClientBleGattService(gatt, it, mutex, connectionProvider) }
 
     /**
      * Finds service based on [uuid].

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -60,5 +60,4 @@ android {
 dependencies {
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/ManufacturerData.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/ManufacturerData.kt
@@ -1,6 +1,7 @@
 package no.nordicsemi.android.kotlin.ble.core.advertiser
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+
 
 /**
  * A helper class which groups manufacturer id and it's data.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/ServiceData.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/advertiser/ServiceData.kt
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.kotlin.ble.core.advertiser
 
 import android.os.ParcelUuid
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 /**
  * A helper class which groups service id and it's data.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/DataByteArray.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/DataByteArray.kt
@@ -1,0 +1,406 @@
+
+/*
+ * Copyright (c) 2024, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.kotlin.ble.core.data.util
+
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.os.Parcelable
+import androidx.annotation.IntRange
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Wrapper around [ByteArray]. There is a problem with [ByteArray] when using inside data class,
+ * because it requires to generate equals() and hashCode() methods. This class do this internally
+ * so there is no need to do this again in data classes which uses [DataByteArray].
+ *
+ * @property value Original [ByteArray] value.
+ */
+//TODO check if [ByteArray] is  Parcelable.
+@Parcelize
+data class DataByteArray(val value: ByteArray = byteArrayOf()) : Parcelable {
+
+    @IgnoredOnParcel
+    val size = value.size
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DataByteArray
+
+        if (!value.contentEquals(other.value)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.contentHashCode()
+    }
+
+    override fun toString(): String {
+        return value.toDisplayString()
+    }
+
+    fun copyOf(): DataByteArray {
+        return DataByteArray(value.copyOf())
+    }
+
+    fun copyOfRange(fromIndex: Int, toIndex: Int): DataByteArray {
+        return DataByteArray(value.copyOfRange(fromIndex, toIndex))
+    }
+
+    fun split(size: Int): List<DataByteArray> {
+        return value.asList().chunked(size).map { DataByteArray(it.toByteArray()) }
+    }
+
+    fun getChunk(offset: Int, mtu: Int): DataByteArray {
+        val maxSize = mtu - 3
+        val sizeLeft = this.size - offset
+        return if (sizeLeft > 0) {
+            if (sizeLeft > maxSize) {
+                this.copyOfRange(offset, offset + maxSize)
+            } else {
+                this.copyOfRange(offset, this.size)
+            }
+        } else {
+            DataByteArray()
+        }
+    }
+
+
+    /**
+     * Returns a byte at the given offset from the byte array.
+     *
+     * @param offset Offset at which the byte value can be found.
+     * @return Cached value or null of offset exceeds value size.
+     */
+    fun getByte(@IntRange(from = 0) offset: Int): Byte? {
+        return value.getOrNull(offset)
+    }
+
+    /**
+     * Returns an integer value from the byte array.
+     *
+     *
+     *
+     * The formatType parameter determines how the value
+     * is to be interpreted. For example, setting formatType to
+     * [.FORMAT_UINT16_LE] specifies that the first two bytes of the
+     * value at the given offset are interpreted to generate the
+     * return value.
+     *
+     * @param formatType The format type used to interpret the value.
+     * @param offset     Offset at which the integer value can be found.
+     * @return Cached value or null of offset exceeds value size.
+     */
+    fun getIntValue(
+        formatType: IntFormat,
+        @IntRange(from = 0) offset: Int
+    ): Int? {
+        if (offset + getTypeLen(formatType) > value.size) {
+            return null
+        }
+
+        when (formatType) {
+            IntFormat.FORMAT_UINT8 -> return unsignedByteToInt(value[offset])
+            IntFormat.FORMAT_UINT16_LE -> return unsignedBytesToInt(value[offset], value[offset + 1])
+            IntFormat.FORMAT_UINT16_BE -> return unsignedBytesToInt(value[offset + 1], value[offset])
+            IntFormat.FORMAT_UINT24_LE -> return unsignedBytesToInt(
+                value[offset],
+                value[offset + 1],
+                value[offset + 2],
+                0.toByte()
+            )
+            IntFormat.FORMAT_UINT24_BE -> return unsignedBytesToInt(
+                value[offset + 2],
+                value[offset + 1],
+                value[offset],
+                0.toByte()
+            )
+            IntFormat.FORMAT_UINT32_LE -> return unsignedBytesToInt(
+                value[offset],
+                value[offset + 1],
+                value[offset + 2],
+                value[offset + 3]
+            )
+            IntFormat.FORMAT_UINT32_BE -> return unsignedBytesToInt(
+                value[offset + 3],
+                value[offset + 2],
+                value[offset + 1],
+                value[offset]
+            )
+            IntFormat.FORMAT_SINT8 -> return unsignedToSigned(unsignedByteToInt(value[offset]), 8)
+            IntFormat.FORMAT_SINT16_LE -> return unsignedToSigned(unsignedBytesToInt(value[offset], value[offset + 1]), 16)
+            IntFormat.FORMAT_SINT16_BE -> return unsignedToSigned(unsignedBytesToInt(value[offset + 1], value[offset]), 16)
+            IntFormat.FORMAT_SINT24_LE -> return unsignedToSigned(
+                unsignedBytesToInt(
+                    value[offset],
+                    value[offset + 1],
+                    value[offset + 2], 0.toByte()
+                ), 24
+            )
+            IntFormat.FORMAT_SINT24_BE -> return unsignedToSigned(
+                unsignedBytesToInt(
+                    0.toByte(),
+                    value[offset + 2],
+                    value[offset + 1],
+                    value[offset]
+                ), 24
+            )
+            IntFormat.FORMAT_SINT32_LE -> return unsignedToSigned(
+                unsignedBytesToInt(
+                    value[offset],
+                    value[offset + 1],
+                    value[offset + 2],
+                    value[offset + 3]
+                ), 32
+            )
+            IntFormat.FORMAT_SINT32_BE -> return unsignedToSigned(
+                unsignedBytesToInt(
+                    value[offset + 3],
+                    value[offset + 2],
+                    value[offset + 1],
+                    value[offset]
+                ), 32
+            )
+        }
+    }
+
+    /**
+     * Returns a long value from the byte array.
+     *
+     * Only [.FORMAT_UINT32_LE] and [.FORMAT_SINT32_LE] are supported.
+     *
+     * The formatType parameter determines how the value
+     * is to be interpreted. For example, setting formatType to
+     * [.FORMAT_UINT32_LE] specifies that the first four bytes of the
+     * value at the given offset are interpreted to generate the
+     * return value.
+     *
+     * @param formatType The format type used to interpret the value.
+     * @param offset     Offset at which the integer value can be found.
+     * @return Cached value or null of offset exceeds value size.
+     */
+    fun getLongValue(
+        formatType: LongFormat,
+        @IntRange(from = 0) offset: Int
+    ): Long? {
+        if (offset + getTypeLen(formatType) > value.size) return null
+        when (formatType) {
+            LongFormat.FORMAT_UINT32_LE -> return unsignedBytesToLong(
+                value[offset],
+                value[offset + 1],
+                value[offset + 2],
+                value[offset + 3]
+            )
+            LongFormat.FORMAT_UINT32_BE -> return unsignedBytesToLong(
+                value[offset + 3],
+                value[offset + 2],
+                value[offset + 1],
+                value[offset]
+            )
+            LongFormat.FORMAT_SINT32_LE -> return unsignedToSigned(
+                unsignedBytesToLong(
+                    value[offset],
+                    value[offset + 1],
+                    value[offset + 2],
+                    value[offset + 3]
+                ), 32
+            )
+            LongFormat.FORMAT_SINT32_BE -> return unsignedToSigned(
+                unsignedBytesToLong(
+                    value[offset + 3],
+                    value[offset + 2],
+                    value[offset + 1],
+                    value[offset]
+                ), 32
+            )
+        }
+    }
+
+    /**
+     * Returns an float value from the given byte array.
+     *
+     * @param formatType The format type used to interpret the value.
+     * @param offset     Offset at which the float value can be found.
+     * @return Cached value at a given offset or null if the requested offset exceeds the value size.
+     */
+    fun getFloatValue(
+        formatType: FloatFormat,
+        @IntRange(from = 0) offset: Int
+    ): Float? {
+        if (offset + getTypeLen(formatType) > value.size) {
+            return null
+        }
+        when (formatType) {
+            FloatFormat.FORMAT_SFLOAT -> {
+                if (value[offset + 1] == 0x07.toByte() && value[offset] == 0xFE.toByte()) {
+                    return Float.POSITIVE_INFINITY
+                }
+                if (value[offset + 1].toInt() == 0x07 && value[offset] == 0xFF.toByte()
+                    || value[offset + 1].toInt() == 0x08 && value[offset].toInt() == 0x00
+                    || value[offset + 1].toInt() == 0x08 && value[offset].toInt() == 0x01
+                ) {
+                    return Float.NaN
+                }
+                return if (value[offset + 1].toInt() == 0x08 && value[offset].toInt() == 0x02) {
+                    Float.NEGATIVE_INFINITY
+                } else {
+                    bytesToFloat(value[offset], value[offset + 1])
+                }
+            }
+            FloatFormat.FORMAT_FLOAT -> {
+                if (value[offset + 3].toInt() == 0x00) {
+                    if (value[offset + 2].toInt() == 0x7F && value[offset + 1] == 0xFF.toByte()) {
+                        if (value[offset] == 0xFE.toByte()) return Float.POSITIVE_INFINITY
+                        if (value[offset] == 0xFF.toByte()) return Float.NaN
+                    } else if (value[offset + 2] == 0x80.toByte() && value[offset + 1].toInt() == 0x00) {
+                        if (value[offset].toInt() == 0x00 || value[offset].toInt() == 0x01) return Float.NaN
+                        if (value[offset].toInt() == 0x02) return Float.NEGATIVE_INFINITY
+                    }
+                }
+                return bytesToFloat(value[offset], value[offset + 1], value[offset + 2], value[offset + 3])
+            }
+        }
+    }
+
+
+    companion object {
+
+        fun from(vararg bytes: Byte): DataByteArray {
+            return DataByteArray(bytes)
+        }
+
+
+        fun from(value: String): DataByteArray {
+            return DataByteArray(value.toByteArray()) // UTF-8
+        }
+
+        fun from(characteristic: BluetoothGattCharacteristic): DataByteArray {
+            return DataByteArray(characteristic.value)
+        }
+
+        fun from(descriptor: BluetoothGattDescriptor): DataByteArray {
+            return DataByteArray(descriptor.value)
+        }
+
+        fun opCode(opCode: Byte): DataByteArray {
+            return DataByteArray(byteArrayOf(opCode))
+        }
+
+        fun opCode(opCode: Byte, parameter: Byte): DataByteArray {
+            return DataByteArray(byteArrayOf(opCode, parameter))
+        }
+
+        /**
+         * Convert a signed byte to an unsigned int.
+         */
+        private fun unsignedByteToInt(b: Byte): Int {
+            return b.toInt() and 0xFF
+        }
+
+        /**
+         * Convert a signed byte to an unsigned int.
+         */
+        private fun unsignedByteToLong(b: Byte): Long {
+            return b.toLong() and 0xFFL
+        }
+
+        /**
+         * Convert signed bytes to a 16-bit unsigned int.
+         */
+        private fun unsignedBytesToInt(b0: Byte, b1: Byte): Int {
+            return unsignedByteToInt(b0) + (unsignedByteToInt(b1) shl 8)
+        }
+
+        /**
+         * Convert signed bytes to a 32-bit unsigned int.
+         */
+        private fun unsignedBytesToInt(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Int {
+            return (unsignedByteToInt(b0) + (unsignedByteToInt(b1) shl 8)
+                    + (unsignedByteToInt(b2) shl 16) + (unsignedByteToInt(b3) shl 24))
+        }
+
+        /**
+         * Convert signed bytes to a 32-bit unsigned long.
+         */
+        private fun unsignedBytesToLong(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Long {
+            return (unsignedByteToLong(b0) + (unsignedByteToLong(b1) shl 8)
+                    + (unsignedByteToLong(b2) shl 16) + (unsignedByteToLong(b3) shl 24))
+        }
+
+        /**
+         * Convert signed bytes to a 16-bit short float value.
+         */
+        private fun bytesToFloat(b0: Byte, b1: Byte): Float {
+            val mantissa = unsignedToSigned(
+                unsignedByteToInt(b0) + (unsignedByteToInt(b1) and 0x0F shl 8),
+                12
+            )
+            val exponent = unsignedToSigned(unsignedByteToInt(b1) shr 4, 4)
+            return (mantissa * Math.pow(10.0, exponent.toDouble())).toFloat()
+        }
+
+        /**
+         * Convert signed bytes to a 32-bit short float value.
+         */
+        private fun bytesToFloat(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Float {
+            val mantissa = unsignedToSigned(
+                unsignedByteToInt(b0)
+                        + (unsignedByteToInt(b1) shl 8)
+                        + (unsignedByteToInt(b2) shl 16),
+                24
+            )
+            return (mantissa * Math.pow(10.0, b3.toDouble())).toFloat()
+        }
+
+        /**
+         * Convert an unsigned integer value to a two's-complement encoded
+         * signed value.
+         */
+        private fun unsignedToSigned(unsigned: Int, size: Int): Int {
+            return unsigned.takeIf { unsigned and (1 shl size - 1) == 0 }
+                ?: (-1 * ((1 shl size - 1) - (unsigned and (1 shl size - 1) - 1)))
+        }
+
+        /**
+         * Convert an unsigned long value to a two's-complement encoded
+         * signed value.
+         */
+        private fun unsignedToSigned(unsigned: Long, size: Int): Long {
+            return unsigned.takeIf { unsigned and (1L shl size - 1) == 0L }
+                ?: (-1 * ((1L shl (size - 1)) - (unsigned.toInt() and (1 shl size - 1) - 1)))
+        }
+    }
+}

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/FloatFormat.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/FloatFormat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Nordic Semiconductor
+ * Copyright (c) 2024, Nordic Semiconductor
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -29,48 +29,18 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.core.wrapper
+package no.nordicsemi.android.kotlin.ble.core.data.util;
 
-import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
-import java.util.UUID
+enum class FloatFormat(valueFormat: ValueFormat) {
+    FORMAT_FLOAT(ValueFormat.FORMAT_FLOAT),
+    FORMAT_SFLOAT(ValueFormat.FORMAT_SFLOAT);
+
+    val value: Int = valueFormat.value
+}
 
 /**
- * Mock variant of the descriptor. It's special feature is that it is independent from
- * Android dependencies and can be used for unit testing.
- *
- * Circular dependency between characteristic and descriptor results in custom [equals],
- * [hashCode] and [toString] implementations.
+ * Returns the size of a give value type.
  */
-data class MockBluetoothGattDescriptor(
-    override val uuid: UUID,
-    override val permissions: Int,
-    override val characteristic: IBluetoothGattCharacteristic,
-    override var value: DataByteArray = DataByteArray()
-) : IBluetoothGattDescriptor {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MockBluetoothGattDescriptor
-
-        if (uuid != other.uuid) return false
-        if (permissions != other.permissions) return false
-        if (characteristic != other.characteristic) return false
-        if (value != other.value) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = uuid.hashCode()
-        result = 31 * result + permissions
-        result = 31 * result + value.hashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        //todo improve
-        return uuid.toString() + value + permissions + characteristic.uuid
-    }
+fun getTypeLen(formatType: FloatFormat): Int {
+    return formatType.value and 0xF
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/IntFormat.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/IntFormat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Nordic Semiconductor
+ * Copyright (c) 2024, Nordic Semiconductor
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -29,48 +29,29 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.core.wrapper
+package no.nordicsemi.android.kotlin.ble.core.data.util;
+enum class IntFormat(valueFormat: ValueFormat) {
+    FORMAT_UINT8(ValueFormat.FORMAT_UINT8),
+    FORMAT_UINT16_LE(ValueFormat.FORMAT_UINT16_LE),
+    FORMAT_UINT16_BE(ValueFormat.FORMAT_UINT16_BE),
+    FORMAT_UINT24_LE(ValueFormat.FORMAT_UINT24_LE),
+    FORMAT_UINT24_BE(ValueFormat.FORMAT_UINT24_BE),
+    FORMAT_UINT32_LE(ValueFormat.FORMAT_UINT32_LE),
+    FORMAT_UINT32_BE(ValueFormat.FORMAT_UINT32_BE),
+    FORMAT_SINT8(ValueFormat.FORMAT_SINT8),
+    FORMAT_SINT16_LE(ValueFormat.FORMAT_SINT16_LE),
+    FORMAT_SINT16_BE(ValueFormat.FORMAT_SINT16_BE),
+    FORMAT_SINT24_LE(ValueFormat.FORMAT_SINT24_LE),
+    FORMAT_SINT24_BE(ValueFormat.FORMAT_SINT24_BE),
+    FORMAT_SINT32_LE(ValueFormat.FORMAT_SINT32_LE),
+    FORMAT_SINT32_BE(ValueFormat.FORMAT_SINT32_BE);
 
-import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
-import java.util.UUID
+    val value: Int = valueFormat.value
+}
 
 /**
- * Mock variant of the descriptor. It's special feature is that it is independent from
- * Android dependencies and can be used for unit testing.
- *
- * Circular dependency between characteristic and descriptor results in custom [equals],
- * [hashCode] and [toString] implementations.
+ * Returns the size of a give value type.
  */
-data class MockBluetoothGattDescriptor(
-    override val uuid: UUID,
-    override val permissions: Int,
-    override val characteristic: IBluetoothGattCharacteristic,
-    override var value: DataByteArray = DataByteArray()
-) : IBluetoothGattDescriptor {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MockBluetoothGattDescriptor
-
-        if (uuid != other.uuid) return false
-        if (permissions != other.permissions) return false
-        if (characteristic != other.characteristic) return false
-        if (value != other.value) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = uuid.hashCode()
-        result = 31 * result + permissions
-        result = 31 * result + value.hashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        //todo improve
-        return uuid.toString() + value + permissions + characteristic.uuid
-    }
+fun getTypeLen(formatType: IntFormat): Int {
+    return formatType.value and 0xF
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/LongFormat.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/LongFormat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Nordic Semiconductor
+ * Copyright (c) 2024, Nordic Semiconductor
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -29,48 +29,20 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.core.wrapper
+package no.nordicsemi.android.kotlin.ble.core.data.util;
 
-import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
-import java.util.UUID
+enum class LongFormat(valueFormat: ValueFormat) {
+    FORMAT_UINT32_LE(ValueFormat.FORMAT_UINT32_LE),
+    FORMAT_UINT32_BE(ValueFormat.FORMAT_UINT32_BE),
+    FORMAT_SINT32_LE(ValueFormat.FORMAT_SINT32_LE),
+    FORMAT_SINT32_BE(ValueFormat.FORMAT_SINT32_BE);
+
+    val value: Int = valueFormat.value
+}
 
 /**
- * Mock variant of the descriptor. It's special feature is that it is independent from
- * Android dependencies and can be used for unit testing.
- *
- * Circular dependency between characteristic and descriptor results in custom [equals],
- * [hashCode] and [toString] implementations.
+ * Returns the size of a give value type.
  */
-data class MockBluetoothGattDescriptor(
-    override val uuid: UUID,
-    override val permissions: Int,
-    override val characteristic: IBluetoothGattCharacteristic,
-    override var value: DataByteArray = DataByteArray()
-) : IBluetoothGattDescriptor {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MockBluetoothGattDescriptor
-
-        if (uuid != other.uuid) return false
-        if (permissions != other.permissions) return false
-        if (characteristic != other.characteristic) return false
-        if (value != other.value) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = uuid.hashCode()
-        result = 31 * result + permissions
-        result = 31 * result + value.hashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        //todo improve
-        return uuid.toString() + value + permissions + characteristic.uuid
-    }
+fun getTypeLen(formatType: LongFormat): Int {
+    return formatType.value and 0xF
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/SparseArrayExt.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/SparseArrayExt.kt
@@ -1,5 +1,6 @@
+
 /*
- * Copyright (c) 2023, Nordic Semiconductor
+ * Copyright (c) 2024, Nordic Semiconductor
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -29,48 +30,16 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.core.wrapper
+package no.nordicsemi.android.kotlin.ble.core.data.util
 
-import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
-import java.util.UUID
+import android.util.SparseArray
 
-/**
- * Mock variant of the descriptor. It's special feature is that it is independent from
- * Android dependencies and can be used for unit testing.
- *
- * Circular dependency between characteristic and descriptor results in custom [equals],
- * [hashCode] and [toString] implementations.
- */
-data class MockBluetoothGattDescriptor(
-    override val uuid: UUID,
-    override val permissions: Int,
-    override val characteristic: IBluetoothGattCharacteristic,
-    override var value: DataByteArray = DataByteArray()
-) : IBluetoothGattDescriptor {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MockBluetoothGattDescriptor
-
-        if (uuid != other.uuid) return false
-        if (permissions != other.permissions) return false
-        if (characteristic != other.characteristic) return false
-        if (value != other.value) return false
-
-        return true
+fun <T, R> SparseArray<T>.map(
+    modifier: (T) -> R,
+): SparseArray<R> {
+    val newArray = SparseArray<R>(this.size())
+    for (i in 0 until this.size()) {
+        newArray[this.keyAt(i)] = modifier(this.valueAt(i))
     }
-
-    override fun hashCode(): Int {
-        var result = uuid.hashCode()
-        result = 31 * result + permissions
-        result = 31 * result + value.hashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        //todo improve
-        return uuid.toString() + value + permissions + characteristic.uuid
-    }
+    return newArray
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/ValueFormat.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/ValueFormat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Nordic Semiconductor
+ * Copyright (c) 2024, Nordic Semiconductor
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -29,53 +29,81 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.core.wrapper
+package no.nordicsemi.android.kotlin.ble.core.data.util
 
-import android.bluetooth.BluetoothGattCharacteristic
-import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
-import java.util.UUID
+enum class ValueFormat(val value: Int) {
+    /**
+     * Data value format type uint8
+     */
+    FORMAT_UINT8(0x11),
+
+    /**
+     * Data value format type uint16
+     */
+    @Deprecated("")
+    FORMAT_UINT16(0x12),
+    FORMAT_UINT16_LE(0x12),
+    FORMAT_UINT16_BE(0x112),
+
+    /**
+     * Data value format type uint24
+     */
+    @Deprecated("")
+    FORMAT_UINT24(0x13),
+    FORMAT_UINT24_LE(0x13),
+    FORMAT_UINT24_BE(0x113),
+
+    /**
+     * Data value format type uint32
+     */
+    @Deprecated("")
+    FORMAT_UINT32(0x14),
+    FORMAT_UINT32_LE(0x14),
+    FORMAT_UINT32_BE(0x114),
+
+    /**
+     * Data value format type sint8
+     */
+    FORMAT_SINT8(0x21),
+
+    /**
+     * Data value format type sint16
+     */
+    @Deprecated("")
+    FORMAT_SINT16(0x22),
+    FORMAT_SINT16_LE(0x22),
+    FORMAT_SINT16_BE(0x122),
+
+    /**
+     * Data value format type sint24
+     */
+    @Deprecated("")
+    FORMAT_SINT24(0x23),
+    FORMAT_SINT24_LE(0x23),
+    FORMAT_SINT24_BE(0x123),
+
+    /**
+     * Data value format type sint32
+     */
+    @Deprecated("")
+    FORMAT_SINT32(0x24),
+    FORMAT_SINT32_LE(0x24),
+    FORMAT_SINT32_BE(0x124),
+
+    /**
+     * Data value format type sfloat (16-bit float, IEEE-11073)
+     */
+    FORMAT_SFLOAT(0x32),
+
+    /**
+     * Data value format type float (32-bit float, IEEE-11073)
+     */
+    FORMAT_FLOAT(0x34)
+}
 
 /**
- * Interface representing bluetooth gatt characteristic. It's task is to hide an implementation
- * which can be both [NativeBluetoothGattCharacteristic] (which is a wrapper around native Android
- * [BluetoothGattCharacteristic]) or [MockBluetoothGattCharacteristic]. The role of an interface
- * is to hide a detailed implementation and separate native Android [BluetoothGattCharacteristic]
- * for mock variant as it can't be unit tested.
+ * Returns the size of a give value type.
  */
-interface IBluetoothGattCharacteristic {
-
-    /**
-     * [UUID] of a characteristic.
-     */
-    val uuid: UUID
-
-    /**
-     * Instance id of a characteristic.
-     */
-    val instanceId: Int
-
-    /**
-     * Not parsed permissions of a characteristic as [Int].
-     */
-    val permissions: Int
-
-    /**
-     * Not parsed properties of a characteristic as [Int].
-     */
-    val properties: Int
-
-    /**
-     * Not parsed write type of a characteristic.
-     */
-    var writeType: Int
-
-    /**
-     * [ByteArray] value of this characteristic.
-     */
-    var value: DataByteArray
-
-    /**
-     * List of descriptors of this characteristic.
-     */
-    val descriptors: List<IBluetoothGattDescriptor>
+fun getTypeLen(formatType: ValueFormat): Int {
+    return formatType.value and 0xF
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/toDisplayString.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/data/util/toDisplayString.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Nordic Semiconductor
+ * Copyright (c) 2024, Nordic Semiconductor
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -29,48 +29,10 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.kotlin.ble.core.wrapper
+package no.nordicsemi.android.kotlin.ble.core.data.util
 
-import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
-import java.util.UUID
-
-/**
- * Mock variant of the descriptor. It's special feature is that it is independent from
- * Android dependencies and can be used for unit testing.
- *
- * Circular dependency between characteristic and descriptor results in custom [equals],
- * [hashCode] and [toString] implementations.
- */
-data class MockBluetoothGattDescriptor(
-    override val uuid: UUID,
-    override val permissions: Int,
-    override val characteristic: IBluetoothGattCharacteristic,
-    override var value: DataByteArray = DataByteArray()
-) : IBluetoothGattDescriptor {
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MockBluetoothGattDescriptor
-
-        if (uuid != other.uuid) return false
-        if (permissions != other.permissions) return false
-        if (characteristic != other.characteristic) return false
-        if (value != other.value) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = uuid.hashCode()
-        result = 31 * result + permissions
-        result = 31 * result + value.hashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        //todo improve
-        return uuid.toString() + value + permissions + characteristic.uuid
+fun ByteArray.toDisplayString(): String {
+    return "(0x) " + this.joinToString(":") {
+        "%02x".format(it).uppercase()
     }
 }

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/event/ValueFlow.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/event/ValueFlow.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 /**
  * Helper class which joins capability of setting up an extra buffer from [MutableSharedFlow] with

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/mapper/ScanRecordSerializer.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/mapper/ScanRecordSerializer.kt
@@ -35,7 +35,7 @@ import android.annotation.SuppressLint
 import android.bluetooth.le.TransportDiscoveryData
 import android.os.ParcelUuid
 import android.util.SparseArray
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.mapper.BleType.DATA_TYPE_FLAGS
 import no.nordicsemi.android.kotlin.ble.core.mapper.BleType.DATA_TYPE_LOCAL_NAME_COMPLETE
 import no.nordicsemi.android.kotlin.ble.core.mapper.BleType.DATA_TYPE_LOCAL_NAME_SHORT

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/AdvertisingDataTypeWithData.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/AdvertisingDataTypeWithData.kt
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.kotlin.ble.core.scanner
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.mapper.BleType
 
 /**

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleScanRecord.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/BleScanRecord.kt
@@ -35,7 +35,7 @@ import android.os.ParcelUuid
 import android.os.Parcelable
 import android.util.SparseArray
 import kotlinx.parcelize.Parcelize
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 /**
  * Represents a scan record from Bluetooth LE scan.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/FilteredManufacturerData.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/FilteredManufacturerData.kt
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.kotlin.ble.core.scanner
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 /**
  * A helper class which groups manufacturer id and it's data.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/FilteredServiceData.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/scanner/FilteredServiceData.kt
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.kotlin.ble.core.scanner
 
 import android.os.ParcelUuid
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 /**
  * A helper class which groups service id, it's data and mask. Used as a scanning filter.

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/IBluetoothGattDescriptor.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/IBluetoothGattDescriptor.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattDescriptor
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import java.util.UUID
 
 /**

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/MockBluetoothGattCharacteristic.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/MockBluetoothGattCharacteristic.kt
@@ -31,7 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
 import java.util.UUID
 

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattCharacteristic.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattCharacteristic.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattCharacteristic
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import java.util.UUID
 
 /**

--- a/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattDescriptor.kt
+++ b/core/src/main/java/no/nordicsemi/android/kotlin/ble/core/wrapper/NativeBluetoothGattDescriptor.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.core.wrapper
 
 import android.bluetooth.BluetoothGattDescriptor
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import java.util.UUID
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 accompanist = "0.34.0"
 androidDesugarJdkLibs = "2.0.4"
-androidGradlePlugin = "8.3.0"
-androidxActivity = "1.8.2"
+androidGradlePlugin = "8.3.2"
+androidxActivity = "1.9.0"
 androidxAnnotation = "1.7.1"
 androidxAppCompat = "1.6.1"
-androidxComposeBom = "2024.02.01" # https://developer.android.com/jetpack/compose/bom/bom-mapping
-androidxComposeCompiler = "1.5.8" # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
+androidxComposeBom = "2024.04.01" # https://developer.android.com/jetpack/compose/bom/bom-mapping
+androidxComposeCompiler = "1.5.12" # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 androidxComposeRuntimeTracing = "1.0.0-beta01"
-androidxCore = "1.12.0"
+androidxCore = "1.13.0"
 androidxCoreSplashscreen = "1.0.1"
-androidxDataStore = "1.0.0"
+androidxDataStore = "1.1.0"
 androidxEspresso = "3.5.1"
 androidxHiltNavigationCompose = "1.2.0"
 androidxLifecycle = "2.7.0"
 androidxLocalbroadcastmanager = "1.1.0"
-androidxMacroBenchmark = "1.2.3"
+androidxMacroBenchmark = "1.2.4"
 androidxNavigation = "2.7.7"
 androidxMetrics = "1.0.0-beta01"
 androidxProfileinstaller = "1.3.1"
@@ -29,23 +29,23 @@ androidxTracing = "1.2.0"
 androidxUiAutomator = "2.3.0"
 androidxWork = "2.9.0"
 coil = "2.6.0"
-firebaseBom = "32.7.3"
-hilt = "2.51"
+firebaseBom = "32.8.1"
+hilt = "2.51.1"
 hiltExt = "1.2.0"
 jacoco = "0.8.7"
 junit4 = "4.13.2"
-kotlin = "1.9.22"
+kotlin = "1.9.23"
 kotlinxCoroutines = "1.8.0"
 kotlinxDatetime = "0.5.0"
 kotlinxSerializationJson = "1.6.3"
-ksp = "1.9.22-1.0.18"
-lint = "31.3.0"
+ksp = "1.9.23-1.0.20"
+lint = "31.3.2"
 memfault-cloud = "2.0.5"
 okhttp = "4.12.0"
 protobuf = "3.25.3"
 protobufPlugin = "0.9.4"
 publishPlugin = "1.2.1"
-retrofit = "2.9.0"
+retrofit = "2.11.0"
 room = "2.6.1"
 paging = "3.2.1"
 secrets = "2.0.1"
@@ -56,25 +56,20 @@ timber = "5.0.1"
 chart = "3.1.0"
 leakcanary = "2.13"
 mockk = "1.13.10"
-slf4j = "2.0.12"
-robolectric = "4.11.1"
+slf4j = "1.7.36" # don't update to 2.x, unless the next one is also updated
+slf4j-timber = "3.1" # <- this one
+robolectric = "4.12.1"
 skydovesBallon = "1.6.4"
 moshiKotlin = "1.15.1"
 moshiAdapters = "1.15.1"
-moshiConverter = "2.9.0"
+moshiConverter = "2.11.0"
 moshi = "1.15.1"
 moshiKotlinCodegen = "1.15.1"
-material3 = "1.2.0"
-material = "1.6.2"
+material3 = "1.2.1"
+material = "1.6.6"
 
-nordic-blek = "1.0.15"
-nordic-ble = "2.7.3"
-nordic-dfu = "2.4.2"
 nordic-log = "2.3.0"
-nordic-mcumgr = "1.9.2"
-nordic-scanner = "1.6.0"
-nordic-common = "1.9.4"
-nordic-memfault = "1.0.2"
+nordic-common = "1.9.5"
 nordicPlugins = "1.11.1"
 dokkaPlugin = "1.9.20"
 googleServicesPlugins = "4.4.1"
@@ -187,7 +182,8 @@ memfault-cloud = { group = "com.memfault.cloud", name = "cloud-android", version
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 chart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "chart" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
-test-slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+slf4j = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+slf4j-timber = { group = "com.arcao", name = "slf4j-timber", version.ref = "slf4j-timber" }
 test-mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 test-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 skydoves-ballon = {group = "com.github.skydoves", name = "balloon-compose", version.ref = "skydovesBallon"}
@@ -198,33 +194,16 @@ moshi = {group = "com.squareup.moshi", name = "moshi", version.ref = "moshi"}
 moshi-kotlin-codegen = {group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshiKotlinCodegen"}
 
 # Nordic
-nordic-ble-ktx = { group = "no.nordicsemi.android", name = "ble-ktx", version.ref = "nordic-ble" }
-nordic-ble-common = { group = "no.nordicsemi.android", name = "ble-common", version.ref = "nordic-ble" }
-nordic-dfu = { group = "no.nordicsemi.android", name = "dfu", version.ref = "nordic-dfu" }
-nordic-mcumgr-core = { group = "no.nordicsemi.android", name = "mcumgr-core", version.ref = "nordic-mcumgr" }
-nordic-mcumgr-ble = { group = "no.nordicsemi.android", name = "mcumgr-ble", version.ref = "nordic-mcumgr" }
 nordic-log = { group = "no.nordicsemi.android", name = "log", version.ref = "nordic-log" }
 nordic-log-timber = { group = "no.nordicsemi.android", name = "log-timber", version.ref = "nordic-log" }
-nordic-scanner = { group = "no.nordicsemi.android.support.v18", name = "scanner", version.ref = "nordic-scanner" }
 nordic-core = { group = "no.nordicsemi.android.common", name = "core", version.ref = "nordic-common" }
 nordic-theme = { group = "no.nordicsemi.android.common", name = "theme", version.ref = "nordic-common" }
 nordic-analytics = { group = "no.nordicsemi.android.common", name = "analytics", version.ref = "nordic-common" }
 nordic-navigation = { group = "no.nordicsemi.android.common", name = "navigation", version.ref = "nordic-common" }
-nordic-uilogger = { group = "no.nordicsemi.android.common", name = "uilogger", version.ref = "nordic-common" }
 nordic-logger = { group = "no.nordicsemi.android.common", name = "logger", version.ref = "nordic-common" }
 nordic-permissions-nfc = { group = "no.nordicsemi.android.common", name = "permissions-nfc", version.ref = "nordic-common" }
 nordic-permissions-ble = { group = "no.nordicsemi.android.common", name = "permissions-ble", version.ref = "nordic-common" }
 nordic-permissions-internet = { group = "no.nordicsemi.android.common", name = "permissions-internet", version.ref = "nordic-common" }
-nordic-memfault = { group = "no.nordicsemi.android", name = "memfault", version.ref = "nordic-memfault" }
-
-# BleK
-nordic-blek-client = { group = "no.nordicsemi.android.kotlin.ble", name = "client", version.ref = "nordic-blek" }
-nordic-blek-server = { group = "no.nordicsemi.android.kotlin.ble", name = "server", version.ref = "nordic-blek" }
-nordic-blek-profile = { group = "no.nordicsemi.android.kotlin.ble", name = "profile", version.ref = "nordic-blek" }
-nordic-blek-core = { group = "no.nordicsemi.android.kotlin.ble", name = "core", version.ref = "nordic-blek" }
-nordic-blek-scanner = { group = "no.nordicsemi.android.kotlin.ble", name = "scanner", version.ref = "nordic-blek" }
-nordic-blek-advertiser = { group = "no.nordicsemi.android.kotlin.ble", name = "advertiser", version.ref = "nordic-blek" }
-nordic-blek-uiscanner = { group = "no.nordicsemi.android.kotlin.ble", name = "uiscanner", version.ref = "nordic-blek" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ markdown = "0.4.1"
 wirePlugin = "4.9.7"
 timber = "5.0.1"
 chart = "3.1.0"
-leakcanary = "2.13"
+leakcanary = "2.14"
 mockk = "1.13.10"
 slf4j = "1.7.36" # don't update to 2.x, unless the next one is also updated
 slf4j-timber = "3.1" # <- this one
@@ -182,7 +182,8 @@ memfault-cloud = { group = "com.memfault.cloud", name = "cloud-android", version
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 chart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "chart" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
-slf4j = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 slf4j-timber = { group = "com.arcao", name = "slf4j-timber", version.ref = "slf4j-timber" }
 test-mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 test-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }

--- a/mock/build.gradle.kts
+++ b/mock/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 
     testImplementation(libs.hilt.android.testing)
     testImplementation(libs.androidx.test.rules)
@@ -71,7 +70,6 @@ dependencies {
     testImplementation(libs.test.mockk)
     testImplementation(libs.androidx.test.ext)
     testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.test.slf4j.simple)
     testImplementation(libs.test.robolectric)
     testImplementation(libs.kotlin.junit)
 }

--- a/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/Mapper.kt
+++ b/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/Mapper.kt
@@ -35,7 +35,7 @@ import android.bluetooth.le.ScanResult
 import android.os.Build
 import android.util.SparseArray
 import androidx.annotation.RequiresApi
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.advertiser.BleAdvertisingConfig
 import no.nordicsemi.android.kotlin.ble.core.mapper.ScanRecordSerializer
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleGattPrimaryPhy

--- a/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/MockEngine.kt
+++ b/mock/src/main/java/no/nordicsemi/android/kotlin/ble/mock/MockEngine.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.mock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent
 import no.nordicsemi.android.kotlin.ble.client.api.ClientGattEvent.*
 import no.nordicsemi.android.kotlin.ble.client.api.GattClientAPI

--- a/profile/build.gradle.kts
+++ b/profile/build.gradle.kts
@@ -59,6 +59,6 @@ android {
 }
 
 dependencies {
+    implementation(project(":core"))
     implementation(libs.androidx.annotation)
-    implementation(libs.nordic.core)
 }

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/battery/BatteryLevelParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/battery/BatteryLevelParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.battery
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 
 object BatteryLevelParser {
 

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/bps/BloodPressureMeasurementParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/bps/BloodPressureMeasurementParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.bps
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.bps.data.BPMStatus
 import no.nordicsemi.android.kotlin.ble.profile.bps.data.BloodPressureMeasurementData
 import no.nordicsemi.android.kotlin.ble.profile.bps.data.BloodPressureType

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/bps/IntermediateCuffPressureParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/bps/IntermediateCuffPressureParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.bps
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.bps.data.BPMStatus
 import no.nordicsemi.android.kotlin.ble.profile.bps.data.BloodPressureType
 import no.nordicsemi.android.kotlin.ble.profile.bps.data.IntermediateCuffPressureData

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMFeatureParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMFeatureParser.kt
@@ -32,8 +32,8 @@
 package no.nordicsemi.android.kotlin.ble.profile.cgm
 
 import android.annotation.SuppressLint
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMFeatures
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMFeaturesEnvelope
 import no.nordicsemi.android.kotlin.ble.profile.common.CRC16

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMMeasurementParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMMeasurementParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.cgm
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMRecord
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMStatus
 import no.nordicsemi.android.kotlin.ble.profile.common.CRC16

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMSpecificOpsControlPointParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMSpecificOpsControlPointParser.kt
@@ -32,9 +32,9 @@
 package no.nordicsemi.android.kotlin.ble.profile.cgm
 
 import android.annotation.SuppressLint
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMCalibrationStatus
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMErrorCode
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMOpCode

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMStatusParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/cgm/CGMStatusParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.cgm
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMStatus
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMStatusEnvelope
 import no.nordicsemi.android.kotlin.ble.profile.common.CRC16

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/common/MutableData.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/common/MutableData.kt
@@ -33,11 +33,11 @@ package no.nordicsemi.android.kotlin.ble.profile.common
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import androidx.annotation.IntRange
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
-import no.nordicsemi.android.common.core.LongFormat
-import no.nordicsemi.android.common.core.getTypeLen
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.LongFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.getTypeLen
 
 class MutableData(  // private final static float FLOAT_EPSILON = 1e-128f;
     var value: ByteArray

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/csc/CSCDataParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/csc/CSCDataParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.csc
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.csc.data.CSCData
 import no.nordicsemi.android.kotlin.ble.profile.csc.data.CSCDataSnapshot
 import no.nordicsemi.android.kotlin.ble.profile.csc.data.WheelSize

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/date/DateTimeParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/date/DateTimeParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.date
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import java.util.Calendar
 
 internal object DateTimeParser {

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/CGMSpecificOpsControlPointDataParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/CGMSpecificOpsControlPointDataParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.gls
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.common.CRC16
 import no.nordicsemi.android.kotlin.ble.profile.common.MutableData
 

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/GlucoseMeasurementContextParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/GlucoseMeasurementContextParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.gls
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.Carbohydrate
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.GLSMeasurementContext
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.Health

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/GlucoseMeasurementParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/GlucoseMeasurementParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.gls
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.date.DateTimeParser
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.ConcentrationUnit
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.GLSRecord

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/RecordAccessControlPointInputParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/RecordAccessControlPointInputParser.kt
@@ -31,9 +31,9 @@
 package no.nordicsemi.android.kotlin.ble.profile.gls
 
 import androidx.annotation.IntRange
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.DataByteArray.Companion.opCode
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray.Companion.opCode
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.common.MutableData
 
 object RecordAccessControlPointInputParser {

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/RecordAccessControlPointParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/gls/RecordAccessControlPointParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.gls
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.NumberOfRecordsData
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.RecordAccessControlPointData
 import no.nordicsemi.android.kotlin.ble.profile.gls.data.ResponseData

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/hrs/BodySensorLocationParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/hrs/BodySensorLocationParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.hrs
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 
 object BodySensorLocationParser {
 

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/hrs/HRSDataParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/hrs/HRSDataParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.hrs
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.hrs.data.HRSData
 
 object HRSDataParser {

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/hts/HTSDataParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/hts/HTSDataParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.hts
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.FloatFormat
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.FloatFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 import no.nordicsemi.android.kotlin.ble.profile.date.DateTimeParser
 import no.nordicsemi.android.kotlin.ble.profile.hts.data.HTSData
 import no.nordicsemi.android.kotlin.ble.profile.hts.data.TemperatureUnit

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/prx/AlarmLevelParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/prx/AlarmLevelParser.kt
@@ -31,8 +31,8 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.prx
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
 
 object AlarmLevelParser {
 

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/prx/AlertLevelInputParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/prx/AlertLevelInputParser.kt
@@ -31,7 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.prx
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 
 object AlertLevelInputParser {
 

--- a/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/rscs/RSCSDataParser.kt
+++ b/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/rscs/RSCSDataParser.kt
@@ -31,9 +31,9 @@
 
 package no.nordicsemi.android.kotlin.ble.profile.rscs
 
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.IntFormat
-import no.nordicsemi.android.common.core.LongFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.IntFormat
+import no.nordicsemi.android.kotlin.ble.core.data.util.LongFormat
 import no.nordicsemi.android.kotlin.ble.profile.rscs.data.RSCSData
 
 object RSCSDataParser {

--- a/scanner/build.gradle.kts
+++ b/scanner/build.gradle.kts
@@ -62,5 +62,4 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/data/Mappers.kt
+++ b/scanner/src/main/java/no/nordicsemi/android/kotlin/ble/scanner/data/Mappers.kt
@@ -37,8 +37,8 @@ import android.os.Build
 import android.os.ParcelUuid
 import android.util.SparseArray
 import androidx.annotation.RequiresApi
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.core.map
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.map
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleScanDataStatus
 import no.nordicsemi.android.kotlin.ble.core.scanner.BleGattPrimaryPhy

--- a/server-android/build.gradle.kts
+++ b/server-android/build.gradle.kts
@@ -61,5 +61,4 @@ dependencies {
     implementation(project(":server-api"))
 
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/server-android/src/main/java/no/nordicsemi/android/kotlin/ble/server/real/NativeServerBleAPI.kt
+++ b/server-android/src/main/java/no/nordicsemi/android/kotlin/ble/server/real/NativeServerBleAPI.kt
@@ -38,7 +38,7 @@ import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.os.Build
 import kotlinx.coroutines.flow.SharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.RealClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus

--- a/server-android/src/main/java/no/nordicsemi/android/kotlin/ble/server/real/ServerBleGattCallback.kt
+++ b/server-android/src/main/java/no/nordicsemi/android/kotlin/ble/server/real/ServerBleGattCallback.kt
@@ -39,7 +39,7 @@ import android.bluetooth.BluetoothGattService
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.RealClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConnectionStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus

--- a/server-api/build.gradle.kts
+++ b/server-api/build.gradle.kts
@@ -60,5 +60,4 @@ dependencies {
     implementation(project(":core"))
 
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/server-api/src/main/java/no/nordicsemi/android/kotlin/ble/server/api/GattServerAPI.kt
+++ b/server-api/src/main/java/no/nordicsemi/android/kotlin/ble/server/api/GattServerAPI.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.server.api
 import android.bluetooth.BluetoothGattServer
 import android.bluetooth.BluetoothGattServerCallback
 import kotlinx.coroutines.flow.SharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy
 import no.nordicsemi.android.kotlin.ble.core.data.PhyOption

--- a/server-api/src/main/java/no/nordicsemi/android/kotlin/ble/server/api/ServerGattEvent.kt
+++ b/server-api/src/main/java/no/nordicsemi/android/kotlin/ble/server/api/ServerGattEvent.kt
@@ -32,7 +32,7 @@
 package no.nordicsemi.android.kotlin.ble.server.api
 
 import android.bluetooth.BluetoothGattServerCallback
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConnectionStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus

--- a/server-mock/build.gradle.kts
+++ b/server-mock/build.gradle.kts
@@ -63,5 +63,4 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 }

--- a/server-mock/src/main/java/no/nordicsemi/android/kotlin/ble/server/mock/MockServerAPI.kt
+++ b/server-mock/src/main/java/no/nordicsemi/android/kotlin/ble/server/mock/MockServerAPI.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.MockServerDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -58,17 +58,15 @@ android {
 
 dependencies {
     api(project(":core"))
-    api(libs.nordic.logger)
+    implementation(libs.slf4j)
 
     implementation(project(":server-api"))
     implementation(project(":mock"))
     implementation(project(":server-mock"))
     implementation(project(":server-android"))
 
-
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.coroutines.android)
-    api(libs.nordic.core)
 
     testImplementation(libs.junit4)
     testImplementation(libs.androidx.test.ext)

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/BluetoothGattServiceFactory.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/BluetoothGattServiceFactory.kt
@@ -36,7 +36,7 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattService
 import android.os.Build
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattConsts
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristic.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristic.kt
@@ -35,7 +35,7 @@ import android.annotation.SuppressLint
 import android.bluetooth.BluetoothGattServerCallback
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.ClientDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristicConfig.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattCharacteristicConfig.kt
@@ -31,7 +31,7 @@
 
 package no.nordicsemi.android.kotlin.ble.server.main.service
 
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattProperty
 import no.nordicsemi.android.kotlin.ble.core.wrapper.IBluetoothGattCharacteristic

--- a/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattDescriptor.kt
+++ b/server/src/main/java/no/nordicsemi/android/kotlin/ble/server/main/service/ServerBleGattDescriptor.kt
@@ -34,7 +34,7 @@ package no.nordicsemi.android.kotlin.ble.server.main.service
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothGattServerCallback
 import kotlinx.coroutines.flow.asSharedFlow
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattOperationStatus
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPermission
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -59,8 +59,6 @@ dependencies {
     implementation(project(":server-mock"))
     implementation(project(":server-api"))
 
-    implementation(libs.nordic.logger)
-
     kaptTest(libs.hilt.compiler)
 
     testImplementation(libs.test.mockk)
@@ -69,7 +67,6 @@ dependencies {
     testImplementation(libs.androidx.test.ext)
     testImplementation(libs.androidx.test.rules)
     testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.test.slf4j.simple)
     testImplementation(libs.test.robolectric)
     testImplementation(libs.hilt.android.testing)
 

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/MutexTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/MutexTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy
 import no.nordicsemi.android.kotlin.ble.core.data.PhyOption

--- a/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/WithTimeoutTest.kt
+++ b/test/src/androidTest/java/no/nordicsemi/android/kotlin/ble/test/WithTimeoutTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import no.nordicsemi.android.common.logger.BleLogger
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
 import no.nordicsemi.android.kotlin.ble.test.utils.BlinkySpecifications
 import no.nordicsemi.android.kotlin.ble.test.utils.TestAddressProvider
@@ -32,15 +31,11 @@ class WithTimeoutTest {
 
     private val testCount = 10
 
-    private val logger = BleLogger { _, log ->
-//        Log.d("AAATESTAAA", log)
-    }
-
     @Test
     fun whenReadCharacteristicMultipleTimesShouldSucceed() = runTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val gatt = ClientBleGatt.connect(context, address, scope, logger = logger)
-        val gatt2 = ClientBleGatt.connect(context, address2, scope, logger = logger)
+        val gatt = ClientBleGatt.connect(context, address, scope)
+        val gatt2 = ClientBleGatt.connect(context, address2, scope)
 
         val services = gatt.discoverServices()
         val services2 = gatt2.discoverServices()

--- a/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/BlinkyServerProvider.kt
+++ b/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/BlinkyServerProvider.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import no.nordicsemi.android.common.core.DataByteArray
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.advertiser.BleAdvertiser
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStarted
 import no.nordicsemi.android.kotlin.ble.advertiser.callback.OnAdvertisingSetStopped

--- a/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/LocalMutexTest.kt
+++ b/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/LocalMutexTest.kt
@@ -6,11 +6,8 @@ import androidx.test.rule.ServiceTestRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
-import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
-import io.mockk.mockk
-import io.mockk.mockkObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -19,13 +16,11 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.logger.BleLogger
-import no.nordicsemi.android.common.logger.DefaultBleLogger
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
 import no.nordicsemi.android.kotlin.ble.core.MockServerDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleGattPhy
 import no.nordicsemi.android.kotlin.ble.core.data.PhyOption
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -73,8 +68,6 @@ class LocalMutexTest {
 
     private val scope = CoroutineScope(UnconfinedTestDispatcher())
 
-    private val logger = BleLogger { _, log -> println(log) }
-
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -93,18 +86,11 @@ class LocalMutexTest {
             server.start(context, serverDevice2)
         }
     }
-
-    @Before
-    fun prepareLogger() {
-        mockkObject(DefaultBleLogger)
-        every { DefaultBleLogger.create(any(), any(), any(), any()) } returns mockk()
-    }
-
     @Test
     fun whenReadRssiMultipleTimesShouldSucceed() = runTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val gatt = ClientBleGatt.connect(context, serverDevice, scope, logger = logger)
-        val gatt2 = ClientBleGatt.connect(context, serverDevice2, scope, logger = logger)
+        val gatt = ClientBleGatt.connect(context, serverDevice, scope)
+        val gatt2 = ClientBleGatt.connect(context, serverDevice2, scope)
 
         repeat(testCount) {
             val jobs = listOf(

--- a/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/ReliableWriteTest.kt
+++ b/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/ReliableWriteTest.kt
@@ -48,8 +48,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.logger.DefaultBleLogger
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
 import no.nordicsemi.android.kotlin.ble.core.MockClientDevice
 import no.nordicsemi.android.kotlin.ble.core.MockServerDevice
@@ -83,9 +82,6 @@ class ReliableWriteTest {
     @RelaxedMockK
     lateinit var context: Context
 
-    @RelaxedMockK
-    lateinit var logger: DefaultBleLogger
-
     @Inject
     lateinit var serverDevice: MockServerDevice
 
@@ -113,12 +109,6 @@ class ReliableWriteTest {
         runBlocking {
             server.start(context, serverDevice)
         }
-    }
-
-    @Before
-    fun prepareLogger() {
-        mockkObject(DefaultBleLogger.Companion)
-        every { DefaultBleLogger.create(any(), any(), any(), any()) } returns mockk()
     }
 
     @Test

--- a/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/WithTimeoutTest.kt
+++ b/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/WithTimeoutTest.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
-import no.nordicsemi.android.common.logger.BleLogger
-import no.nordicsemi.android.common.logger.DefaultBleLogger
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
 import no.nordicsemi.android.kotlin.ble.core.MockServerDevice
 import org.junit.After
@@ -70,8 +68,6 @@ class WithTimeoutTest {
 
     private val scope = CoroutineScope(UnconfinedTestDispatcher())
 
-    private val logger = BleLogger { _, log -> println(log) }
-
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -89,12 +85,6 @@ class WithTimeoutTest {
             server.start(context, serverDevice)
             server.start(context, serverDevice2)
         }
-    }
-
-    @Before
-    fun prepareLogger() {
-        mockkObject(DefaultBleLogger)
-        every { DefaultBleLogger.create(any(), any(), any(), any()) } returns mockk()
     }
 
     @Test

--- a/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/WriteNoResponseTest.kt
+++ b/test/src/test/java/no/nordicsemi/android/kotlin/ble/test/WriteNoResponseTest.kt
@@ -5,11 +5,8 @@ import androidx.test.rule.ServiceTestRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
-import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
-import io.mockk.mockk
-import io.mockk.mockkObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -17,12 +14,11 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import no.nordicsemi.android.common.core.DataByteArray
-import no.nordicsemi.android.common.logger.DefaultBleLogger
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
 import no.nordicsemi.android.kotlin.ble.core.MockClientDevice
 import no.nordicsemi.android.kotlin.ble.core.MockServerDevice
 import no.nordicsemi.android.kotlin.ble.core.data.BleWriteType
+import no.nordicsemi.android.kotlin.ble.core.data.util.DataByteArray
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -49,9 +45,6 @@ class WriteNoResponseTest {
 
     @RelaxedMockK
     lateinit var context: Context
-
-    @RelaxedMockK
-    lateinit var logger: DefaultBleLogger
 
     @Inject
     lateinit var serverDevice: MockServerDevice
@@ -80,12 +73,6 @@ class WriteNoResponseTest {
         runBlocking {
             server.start(context, serverDevice)
         }
-    }
-
-    @Before
-    fun prepareLogger() {
-        mockkObject(DefaultBleLogger)
-        every { DefaultBleLogger.create(any(), any(), any(), any()) } returns mockk()
     }
 
     @Test


### PR DESCRIPTION
This PR updates dependency versions. It also removes dependency to Nordic Common library, which fixes #119.

Changes:
1. `DataByteArray`  moved from Commons:core to local package,
2. As logging utils were removed from Common library, this PR migrates logging in BLEK to use `slf4j-api`. Logs can be integrated with LogCat using `libs.slf4j.timber` dependency, like shown in _:app-client_ and _app-server_.
3. Log messages were improved and simplified.