### PR TITLE
Allowing filtering with filter selected and unselected

### DIFF
--- a/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/Destinations.kt
+++ b/app_client/src/main/java/no/nordicsemi/android/kotlin/ble/app/client/Destinations.kt
@@ -1,7 +1,6 @@
 package no.nordicsemi.android.kotlin.ble.app.client
 
 import android.os.ParcelUuid
-import androidx.compose.material3.MaterialTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import no.nordicsemi.android.common.navigation.createDestination
 import no.nordicsemi.android.common.navigation.createSimpleDestination
@@ -26,10 +25,10 @@ val ScannerDestination = defineDestination(ScannerDestinationId) {
     val uuid = ParcelUuid(BlinkySpecifications.UUID_SERVICE_DEVICE)
     val filters = listOf(
         WithServiceUuid("Blinky", uuid, true),
-        OnlyNearby(rssi = -50 /* dBm */, initiallyEnabled = false),
-        OnlyWithNames(initiallyEnabled = true),
-        CustomFilter("Nordic", false) {
-            it.device.name?.contains("nordic", ignoreCase = true) == true
+        OnlyNearby(rssi = -50 /* dBm */, initiallySelected = false),
+        OnlyWithNames(initiallySelected = true),
+        CustomFilter("Nordic", false) { isFilterSelected, result ->
+            !isFilterSelected || result.device.name?.contains("nordic", ignoreCase = true) == true
         }
     )
     ScannerScreen(

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/ScannerView.kt
@@ -80,6 +80,7 @@ fun ScannerView(
         ) { isLocationRequiredAndDisabled ->
             val viewModel = hiltViewModel<ScannerViewModel>()
             LaunchedEffect(key1 = Unit) {
+                print("Launch effect")
                 viewModel.setFilters(filters)
             }
 

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/main/viewmodel/ScannerViewModel.kt
@@ -112,7 +112,7 @@ internal class ScannerViewModel @Inject constructor(
     private fun List<BleScanResults>.applyFilters(config: List<ScanFilterState>) =
             filter { result ->
                 config.all {
-                    !it.selected || it.predicate(result)
+                    it.predicate(it.selected, result)
                 }
             }
 
@@ -120,7 +120,7 @@ internal class ScannerViewModel @Inject constructor(
         this.filters = filters
         this._filterConfig.update {
             filters.map {
-                ScanFilterState(it.title, it.initiallyEnabled, it.filter)
+                ScanFilterState(it.title, it.initiallySelected, it.filter)
             }
         }
     }

--- a/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/FilterView.kt
+++ b/uiscanner/src/main/java/no/nordicsemi/android/kotlin/ble/ui/scanner/view/internal/FilterView.kt
@@ -53,7 +53,7 @@ import no.nordicsemi.android.kotlin.ble.ui.scanner.R
 internal data class ScanFilterState(
     val title: String,
     val selected: Boolean,
-    val predicate: (BleScanResults) -> Boolean,
+    val predicate: (isFilterSelected: Boolean, result: BleScanResults) -> Boolean,
 )
 
 @Composable
@@ -95,17 +95,17 @@ private fun FilterViewPreview() {
                     ScanFilterState(
                         title = stringResource(id = R.string.filter_uuid),
                         selected = true,
-                        predicate = { true },
+                        predicate = { selected,_ -> selected },
                     ),
                     ScanFilterState(
                         title = stringResource(id = R.string.filter_nearby),
                         selected = false,
-                        predicate = { true },
+                        predicate = { selected,_ -> selected },
                     ),
                     ScanFilterState(
                         title = stringResource(id = R.string.filter_name),
                         selected = true,
-                        predicate = { true },
+                        predicate = { selected,_ -> selected },
                     ),
                 ),
                 onChanged = {},


### PR DESCRIPTION
This PR modifies #148 by allowing filtering in both states: selected and unselected.

This allows to create "All" filter like before, which was filtering when unselected, or "Unprovisioned", which filters for supported devices in any of the states in addition to filtering provisioning state.