### PR TITLE
Nordic plugins set to 2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ material = "1.6.8"
 
 nordic-log = "2.3.0"
 nordic-common = "2.0.0"
-nordicPlugins = "2.2.4"
+nordicPlugins = "2.3"
 dokkaPlugin = "1.9.20"
 googleServicesPlugins = "4.4.2"
 firebaseCrashlyticsPlugins = "3.0.2"


### PR DESCRIPTION
The 2.3 update migrated release scripts to use Dokka instead of Javadoc.
Javadoc was failing to compile using Java 17: https://github.com/Kotlin/dokka/issues/2956