### PR TITLE
Allow scanning for Manufacturer Data by Company ID only

### DIFF
--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/ScanFilterScope.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/ScanFilterScope.kt
@@ -102,6 +102,14 @@ sealed interface ScanFilterScope: CentralManager.ScanFilterScope {
     fun ManufacturerData(companyId: Int, data: ByteArray, mask: ByteArray? = null)
 
     /**
+     * Filters devices by any manufacturer data defined by a company with given ID.
+     *
+     * @param companyId the company ID as defined by the Bluetooth SIG.
+     */
+    @Suppress("FunctionName")
+    fun ManufacturerData(companyId: Int)
+
+    /**
      * Filters devices advertising a specific AD type.
      */
     @Suppress("FunctionName")

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -104,7 +104,10 @@ class ScannerViewModel @Inject constructor(
         _isScanning.update { true }
         scanningJob = centralManager
             .scan(5000.milliseconds) {
-                ServiceUuid(Uuid.fromShortUuid(0x1809))
+                Any {
+                    ManufacturerData(0x0059)
+                    ServiceUuid(Uuid.fromShortUuid(0x1809))
+                }
                 Any {
                     Name("Pixel 5")
                     Name("Pixel 7")


### PR DESCRIPTION
This PR fixes #172.

I checked, that the native Android API allows for `null` in `manufacturerData` as long as `companyId > 0` (for some reason).
It also only checks the bytes up-to to the given filter length, so if filter data are empty - it only checks for Company ID.

I tested the new feaure and it seems to be working fine.