### PR TITLE
Bugfix: Correctly scan for name as Regex

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/ScanFilterUtils.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/ScanFilterUtils.kt
@@ -56,6 +56,7 @@ internal fun List<ScanFilter>.toNative(): List<NativeScanFilter> = mapNotNull { 
 @OptIn(ExperimentalUuidApi::class)
 internal fun ScanFilter.toNative(): NativeScanFilter? {
     if (name == null &&
+        nameRegex == null &&
         serviceUuid == null &&
         serviceData == null &&
         manufacturerData == null &&

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/ScanFilters.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/ScanFilters.kt
@@ -325,7 +325,7 @@ class ScanFilter {
             }
         }
         nameRegex?.let { nameRegex ->
-            if (advertisingData.name?.matches(nameRegex) == false) {
+            if (advertisingData.name?.matches(nameRegex) != true) {
                 return false
             }
         }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -117,6 +117,7 @@ class ScannerViewModel @Inject constructor(
                     Name("Mesh Light")
                     Name("nRFConnect")
                     Name("HR Sensor")
+                    Name(Regex("Mesh.*"))
                 }
             }
             .distinctByPeripheral()


### PR DESCRIPTION
This PR fixes a bug, where no scan results are returned if one scans with the following filters:

```kotlin
Any {
  Name("Some Name")
  Name(Regex("Prefix.*")
}
```
if there is a device advertising with some Prefix.

The regular names were converted to `ScanFilter` and applied to the scanner, so no other result was passed. As the regex condition is checked only in the library, after results are delivered, no devices were reported.

The change adds an empty filter in this case with no name to be passed for the sake of checking it against all filters in the library.