### PR TITLE
Disconnection improvements

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeExecutor.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeExecutor.kt
@@ -218,16 +218,18 @@ internal class NativeExecutor(
     }
 
     override fun close() {
-        try {
-            gatt?.disconnect()
-        } catch (_: Exception) {
-            // Ignore
+        gatt?.let { gatt ->
+            this.gatt = null
+            try {
+                gatt.disconnect()
+            } catch (_: Exception) {
+                // Ignore
+            }
+            try {
+                gatt.close()
+            } catch (_: Exception) {
+                // Ignore
+            }
         }
-        try {
-            gatt?.close()
-        } catch (_: Exception) {
-            // Ignore
-        }
-        gatt = null
     }
 }

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
@@ -93,6 +93,10 @@ sealed class ConnectionState {
              * @property duration The duration of the timeout.
              */
             data class Timeout(val duration: Duration): Reason()
+
+            /** A quick check whether the disconnection was initiated by the user. */
+            val isUserInitiated: Boolean
+                get() = this is Success || this is Cancelled
         }
     }
 


### PR DESCRIPTION
This PR improves handing disconnection:
1. When `peripheral.close()` was called twice in a row, the `gatt.disconnect()` and `gatt.close()` methods were called twice.
2. Closing Central Manager's scope will also close the Central Manager and its periipherals.
3. A helper method added to `ConnectionState.Disconnected.Reason` to check whether the disconnection was user initiated.