### PR TITLE
Breaking: service discovery API improvement

### DIFF
--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -346,9 +346,6 @@ class ScannerViewModel @Inject constructor(
                     }
                 }
             }
-            .onEmpty {
-                Timber.w("No services found")
-            }
             .onCompletion {
                 Timber.d("Service collection completed")
             }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
@@ -309,6 +310,7 @@ class ScannerViewModel @Inject constructor(
     @OptIn(ExperimentalStdlibApi::class, ExperimentalUuidApi::class)
     private fun observerServices(peripheral: Peripheral, scope: CoroutineScope) {
         peripheral.services()
+            .filterNotNull()
             .onEach {
                 Timber.i("Services changed: $it")
 


### PR DESCRIPTION
`peripheral.services()` returns a `StateFlow`, hence must have an initial state.

### Before

`peripheral.services()` was returning an empty list.

This was problematic, as it was not possible to figure out whether a device had a specific service, or not, when service discovery was done with a filter. Initial state of this flow was `[]`, and when the required service was not found, the flow did not emit anything.

### After

The returned type of `peripheral.services(...)` was changed to optional: `List<RemoteService>?` with `null` as an initial state. When service discovery is complete, the flow emits `[]` indicating that the service was not found.