### PR TITLE
Make sure the `disconnect()` method closes AutoConnect connection

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -463,6 +463,8 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
         // Check if the peripheral isn't already disconnected or has a pending disconnection.
         state.value.let { currentState ->
             if (currentState is ConnectionState.Disconnected) {
+                // Make sure the AutoConnect also gets cancelled if the peripheral is currently disconnected.
+                close()
                 return
             }
             if (currentState is ConnectionState.Disconnecting) {


### PR DESCRIPTION
Before, when the device, which was connected using `ConnectionOptions.AutoConnect` was disconnected at the moment when `peripheral.disconnect()` was called, the automatic connection was not stopped.

This change makes sure that the `gatt.close` gets called.