### PR TITLE
Unnecessary generic type removed from `CentralManagerImpl` type

### DIFF
--- a/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockCentralManagerImpl.kt
+++ b/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockCentralManagerImpl.kt
@@ -76,7 +76,7 @@ import kotlin.time.Duration
 open class MockCentralManagerImpl(
     scope: CoroutineScope,
     private val environment: MockEnvironment = LatestApi(),
-): MockCentralManager, CentralManagerImpl<Unit>(scope, Unit) {
+): MockCentralManager, CentralManagerImpl(scope) {
     private val logger = LoggerFactory.getLogger(MockCentralManagerImpl::class.java)
 
     // Simulation methods

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeCentralManagerImpl.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeCentralManagerImpl.kt
@@ -89,7 +89,7 @@ import android.bluetooth.le.ScanSettings as NativeScanSettings
 internal class NativeCentralManagerImpl(
     context: Context,
     scope: CoroutineScope,
-): CentralManagerImpl<Context>(scope) {
+): CentralManagerImpl(scope) {
     private val logger = LoggerFactory.getLogger(NativeCentralManagerImpl::class.java)
 
     /**

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/CentralManagerImpl.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/CentralManagerImpl.kt
@@ -45,10 +45,9 @@ import no.nordicsemi.kotlin.ble.core.exception.ManagerClosedException
 /**
  * Android-specific implementation of a central manager interface.
  *
- * @param C The context type.
  * @param scope The coroutine scope.
  */
-abstract class CentralManagerImpl<C: Any>(
+abstract class CentralManagerImpl(
     scope: CoroutineScope,
 ): CentralManagerImpl<String, Peripheral, Peripheral.Executor, ConjunctionFilterScope, ScanResult>(scope),
     CentralManager {


### PR DESCRIPTION
This is only internal implementation.