### PR TITLE
Bugfix: `close()` was unregistering broadcast receivers twice

### DIFF
--- a/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockCentralManagerImpl.kt
+++ b/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockCentralManagerImpl.kt
@@ -61,6 +61,7 @@ import no.nordicsemi.kotlin.ble.client.exception.BluetoothUnavailableException
 import no.nordicsemi.kotlin.ble.client.mock.PeripheralSpec
 import no.nordicsemi.kotlin.ble.client.mock.internal.MockBluetoothLeAdvertiser
 import no.nordicsemi.kotlin.ble.core.Manager
+import no.nordicsemi.kotlin.ble.core.Manager.State.UNKNOWN
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PrimaryPhy
 import no.nordicsemi.kotlin.ble.core.exception.ManagerClosedException
@@ -307,11 +308,10 @@ open class MockCentralManagerImpl(
 
     override fun close() {
         // Ignore if already closed.
-        if (!isOpen)
-            return
+        if (!isOpen) return
+        super.close()
 
         // Set the state to unknown.
-        _state.update { Manager.State.UNKNOWN }
-        super.close()
+        _state.update { UNKNOWN }
     }
 }

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeCentralManagerImpl.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeCentralManagerImpl.kt
@@ -319,14 +319,18 @@ internal class NativeCentralManagerImpl(
     override fun close() {
         // Ignore if already closed.
         if (!isOpen) return
+        super.close()
 
         // Release resources.
-        applicationContext.unregisterReceiver(stateBroadcastReceiver)
-        applicationContext.unregisterReceiver(bondStateBroadcastReceiver)
+        try {
+            applicationContext.unregisterReceiver(stateBroadcastReceiver)
+            applicationContext.unregisterReceiver(bondStateBroadcastReceiver)
+        } catch (_: Exception) {
+            // Ignore
+        }
 
         // Set the state to unknown.
         _state.update { UNKNOWN }
-        super.close()
     }
 
     // ---- Private implementation ----


### PR DESCRIPTION
`centralManager.close()` was unregistering broadcast receivers twice and crashing when called simultaneously.
The second call was introduced in #190. 