### PR TITLE
Breaking: `getPeripheralById` no longer returns null

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/CentralManager.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/CentralManager.kt
@@ -58,23 +58,25 @@ interface CentralManager<
 >: Manager {
 
     /**
-     * Returns a list of peripherals discovered by this instance of the Central Manager.
+     * A list of peripherals that the central manager is able to match to the provided identifiers.
      *
      * @param ids List of peripheral identifiers.
      * @return List of peripherals. The list may have a smaller size than the input list.
      * @throws ManagerClosedException If the central manager has been closed.
      * @throws BluetoothUnavailableException If Bluetooth is disabled or not available.
+     * @throws IllegalArgumentException If any of the identifiers is not valid.
      * @see [Peer.identifier]
      */
     fun getPeripheralsById(ids: List<ID>): List<P>
 
     /**
-     * Returns a list of peripherals discovered by this instance of the Central Manager.
+     * A peripheral that the central manager is able to match to the provided identifier.
      *
      * @param id The peripheral identifier.
      * @return A peripheral associated with the given UUID, if found.
      * @throws ManagerClosedException If the central manager has been closed.
      * @throws BluetoothUnavailableException If Bluetooth is disabled or not available.
+     * @throws IllegalArgumentException If the identifier is not valid.
      * @see [Peer.identifier]
      */
     fun getPeripheralById(id: ID): P? = getPeripheralsById(listOf(id)).firstOrNull()


### PR DESCRIPTION
Just like `BluetoothAdapter.getRemoteDevice(..)` always returns a `BluetoothDevice`, 
the `centralManager.getPeripheralById(...)` always can return a `Peripheral`.

In mock implementation, if the is no `PeripheralSpec` for the given id, a "dummy" one will be created. The simulated peripheral won't advertise and won't be reachable, just as if someone tried to connect to an unreachable device.

### iOS Consideration

On iOS, the [retrieveperipherals(withidentifiers:)](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/retrieveperipherals(withidentifiers:)) method may not return a `CBPeripheral` for some random UUID, therefore we cannot guarantee, that the list returned by `getPeripheralsById` will have the same size as the provided list of ids, hence the `getPeripheralById` may return `null`.

This should not happen on Android.