### PR TITLE
New disconnection reason: Insufficient Authentication

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
@@ -85,6 +85,7 @@ internal fun Int.toConnectionState(status: Int): ConnectionState = when (this) {
 private fun Int.toDisconnectionReason(): ConnectionState.Disconnected.Reason = when (this) {
     BluetoothGatt.GATT_SUCCESS -> ConnectionState.Disconnected.Reason.Success
     0x08 /* GATT_CONN_TIMEOUT */ -> ConnectionState.Disconnected.Reason.LinkLoss
+    0x05 /* GATT_INSUFFICIENT_AUTHENTICATION */ -> ConnectionState.Disconnected.Reason.InsufficientAuthentication
     0x13 /* GATT_CONN_TERMINATE_PEER_USER */ -> ConnectionState.Disconnected.Reason.TerminatePeerUser
     0x16 /* GATT_CONN_TERMINATE_LOCAL_HOST */ -> ConnectionState.Disconnected.Reason.TerminateLocalHost
     else -> ConnectionState.Disconnected.Reason.Unknown(this)

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
@@ -68,8 +68,16 @@ sealed class ConnectionState {
             data class Unknown(val status: Int): Reason()
             /** The local device initiated disconnection.  */
             data object TerminateLocalHost: Reason()
-            /** The remote device initiated graceful disconnection.  */
+            /** The remote device initiated graceful disconnection. */
             data object TerminatePeerUser: Reason()
+            /**
+             * Insufficient authentication.
+             *
+             * This error is returned when the Android device tries to enable security on a
+             * device that had its bond information removed. Remove bond information on the phone
+             * and retry.
+             */
+            data object InsufficientAuthentication: Reason()
             /** The device got out of range or has turned off. */
             data object LinkLoss: Reason()
             /** Connection attempt was cancelled.  */

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
@@ -50,9 +50,11 @@ sealed class ConnectionState {
     data object Disconnecting: ConnectionState()
 
     /**
-     * Device is disconnected.
+     * Device has disconnected.
      *
-     * @param reason Reason of disconnection, or _null_ if no connection attempt was made.
+     * This state may be immediately followed by [Closed] state.
+     *
+     * @param reason Reason of disconnection.
      */
     data class Disconnected(val reason: Reason): ConnectionState() {
 
@@ -89,7 +91,7 @@ sealed class ConnectionState {
              * background connection list. RPA is allowed for direct connection, as such request
              * times out after a short period of time.
              *
-             * See: https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Bluetooth/system/stack/gatt/gatt_api.cc;l=1450
+             * See: [Source code](https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Bluetooth/system/stack/gatt/gatt_api.cc;l=1498)
              */
             data object UnsupportedAddress: Reason()
             /**


### PR DESCRIPTION
A remote device was erased and flashed with firmware that supports bonding.
On Android phone I had bond information from the previous connection, no longer valid.
When trying to connect Android is not able to re-establish security and fails with error 5 (_GATT_INSUFFICIENT_AUTHENTICATION_).

This error is now reported as `Disconnected.Reason.InsufficientAuthentication`.