### PR TITLE
Report error 137 as Insufficient Auth

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
@@ -215,6 +215,7 @@ internal fun Int.toOperationStatus(): OperationStatus = when (this) {
     BluetoothGatt.GATT_INVALID_OFFSET -> OperationStatus.INVALID_OFFSET
     BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH -> OperationStatus.INVALID_ATTRIBUTE_LENGTH
     133 -> OperationStatus.GATT_ERROR
+    137 -> OperationStatus.INSUFFICIENT_AUTHENTICATION
     else -> OperationStatus.UNKNOWN_ERROR
 }
 


### PR DESCRIPTION
This happens when Pixel 4 with Android 12 connects to a device that is bonded with some other phone and tries to read the value of a protected characteristic. As there's no encryption, this error is thrown. Android does not try to bond.

Pixel 7 with Adnrtoid 15 tries to bond instead. 