### PR TITLE
`Closed` connection state removed in favor of `Disconnected`

### DIFF
--- a/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockExecutor.kt
+++ b/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockExecutor.kt
@@ -59,7 +59,7 @@ open class MockExecutor(
     name: String?,
 ): Peripheral.Executor {
     override val type: PeripheralType = peripheralSpec.type
-    override val initialState: ConnectionState = ConnectionState.Closed
+    override val initialState: ConnectionState = ConnectionState.Disconnected()
     override val initialServices: List<RemoteService> = emptyList()
 
     override val identifier: String = peripheralSpec.identifier

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeExecutor.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeExecutor.kt
@@ -76,7 +76,7 @@ internal class NativeExecutor(
     } catch (_: SecurityException) {
         name
     }
-    override val initialState: ConnectionState = ConnectionState.Closed
+    override val initialState: ConnectionState = ConnectionState.Disconnected()
     override val initialServices: List<RemoteService> = emptyList()
 
     /**

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -260,15 +260,15 @@ open class Peripheral(
                             // direct connection.
                             //
                             // See: https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Bluetooth/system/stack/gatt/gatt_api.cc;l=1450
-                            val reason = state.reason
+                            val reason = state.reason!!
                             if (reason is Reason.Unknown && (reason.status == 133 || reason.status == 135)) {
                                 logger.warn("Connection attempt failed (reason: {})", Reason.UnsupportedAddress)
                                 _state.update { ConnectionState.Disconnected(Reason.UnsupportedAddress) }
                                 throw ConnectionFailedException(Reason.UnsupportedAddress)
                             }
-                            logger.warn("Connection attempt failed (reason: {})", state.reason)
+                            logger.warn("Connection attempt failed (reason: {})", reason)
                             _state.update { state }
-                            throw ConnectionFailedException(state.reason)
+                            throw ConnectionFailedException(reason)
                         }
                         else -> {}
                     }
@@ -309,9 +309,10 @@ open class Peripheral(
                         }
                         is ConnectionState.Disconnected -> {
                             check(options.retry > 0) {
-                                logger.warn("Connection attempt failed (reason: {})", state.reason)
+                                val reason = state.reason!!
+                                logger.warn("Connection attempt failed (reason: {})", reason)
                                 _state.update { state }
-                                throw ConnectionFailedException(state.reason)
+                                throw ConnectionFailedException(reason)
                             }
                             logger.warn("Connection attempt failed (reason: {}), retrying in {}...",
                                 state.reason, options.retryDelay)
@@ -581,7 +582,6 @@ open class Peripheral(
      * by [services] will emit an empty list of services following by updated list of services
      * when the new service discovery is complete.
      *
-     * The peripheral must be in any state other then [ConnectionState.Closed].
      * It is safe to call this method when the peripheral is connected, connecting, or disconnecting.
      * It may be called when the device is disconnected but only when the connection was made using
      * [AutoConnect][CentralManager.ConnectionOptions.AutoConnect] option in which case the system
@@ -590,9 +590,9 @@ open class Peripheral(
      * A connection made using [Direct][CentralManager.ConnectionOptions.Direct] option closes
      * automatically immediately after disconnection.
      *
-     * When invoked when closed the method throws [PeripheralClosedException].
+     * When invoked on a closed connection the method throws [PeripheralClosedException].
      *
-     * @throws PeripheralClosedException If the peripheral is in [Closed][ConnectionState.Closed] state.
+     * @throws PeripheralClosedException If the peripheral is closed.
      * @throws OperationFailedException If cache could not be refreshed.
      * @throws SecurityException If BLUETOOTH_CONNECT permission is denied.
      */

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -386,7 +386,7 @@ open class PreviewPeripheral(
     type: PeripheralType = PeripheralType.LE,
     rssi: Int = -40, // dBm
     phy: PhyInUse = PhyInUse.PHY_LE_1M,
-    state: ConnectionState = ConnectionState.Closed,
+    state: ConnectionState = ConnectionState.Disconnected(),
     services: ServerScope.() -> Unit = {
         Service(Service.GENERIC_ACCESS_UUID) {
             Characteristic(

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
@@ -57,10 +57,10 @@ sealed class GattEvent {
 data class ConnectionStateChanged(val newState: ConnectionState) : GattEvent() {
 
     /**
-     * Returns whether the new state is [ConnectionState.Disconnected] or [ConnectionState.Closed].
+     * Returns whether the new state is [ConnectionState.Disconnected].
      */
     val disconnected: Boolean
-        get() = newState is ConnectionState.Disconnected || newState is ConnectionState.Closed
+        get() = newState is ConnectionState.Disconnected
 }
 
 /**

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
@@ -355,7 +354,6 @@ class ScannerViewModel @Inject constructor(
 
     private fun observePeripheralState(peripheral: Peripheral, scope: CoroutineScope) {
         peripheral.state
-            .buffer()
             .onEach {
                 Timber.i("State of $peripheral: $it")
 
@@ -367,7 +365,7 @@ class ScannerViewModel @Inject constructor(
                         }
                     }
 
-                    is ConnectionState.Closed -> {
+                    is ConnectionState.Disconnected -> {
                         // Just for testing, wait with cancelling the scope to get all the logs.
                         delay(500)
                         // Cancel connection scope, so that previously launched jobs are cancelled.


### PR DESCRIPTION
This PR breaks the existing API.

It removes the `ConnectionState.Closed` state.

### Reasons

There are 2 reasons why the change was made:
1. The transition from `Disconnected(reason)` to `Closed` was so fast, that it was missed by flow collectors running on the main dispatcher. That means, the reason of disconnection was lost.
```mermaid
stateDiagram
    Connected-->Disconnecting: disconnect()
    Disconnecting-->Disconnected: success
    note left of Disconnected
            Reason given as parameter is never caught.
    end note
    Disconnected-->Closed: immediate transition
```
2. In auto-connect mode, the initial connection (through `Connecting` state) differed from the reconnections (without `Connecting` state). The state diagram looked like that:
```mermaid
stateDiagram
    Closed-->Connecting: connect(AutoConnect)
    Connecting-->Connected: connection created
    Connected-->Disconnected(LinkLoss): link loss
    Disconnected(LinkLoss)-->Connected: reconnection
    Disconnected(LinkLoss)-->Disconnecting: disconnect()
    Connected-->Disconnecting: disconnect()
    Disconnecting-->Disconnected: success
    Disconnected-->Closed: immediate transition
```

### After the change

The new approach removes the `Closed` state. The `Connecting` is always used to indicate, that the device is trying to connect. There is a possible transition from `Connected` to `Connecting` in auto-connect mode, meaning that the link was lost, but the phone is trying to reconnect.
#### Auto Connect
```mermaid
stateDiagram
    Disconnected-->Connecting: connect(AutoConnect)
    note left of Disconnected
            Reason given as parameter, initially null.
    end note
    Connecting-->Connected: connection created
    Connected-->Connecting: link loss
    Connected-->Disconnecting: disconnect()
    Disconnecting-->Disconnected: success
```
#### Direct
```mermaid
stateDiagram-v2
    Disconnected-->Connecting: connect(Direct)
    note left of Disconnected
            Reason given as parameter, initially null.
    end note
    Connecting-->Connected: connection created
    Connected-->Disconnected: link loss
    Connected-->Disconnecting: disconnect()
    Disconnecting-->Disconnected: success
```