### PR TITLE
Disconnection issue fixed

### DIFF
--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -358,7 +358,7 @@ open class Peripheral(
             } catch (_: PeripheralNotConnectedException) {
                 // Skip service discovery if the peripheral got disconnected.
                 return
-            } catch (e: Exception) {
+            } catch (e: OperationFailedException) {
                 logger.warn("Failed to request MTU: {}", e.message)
             }
         }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/exception/PeripheralClosedException.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/exception/PeripheralClosedException.kt
@@ -38,6 +38,6 @@ import no.nordicsemi.kotlin.ble.client.android.Peripheral
  * Thrown when the peripheral wasn't connected or has been closed.
  * 
  * This exception is thrown from [Peripheral.refreshCache] when the underlying GATT
- * object is null..
+ * object is null.
  */
 class PeripheralClosedException: BluetoothException()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -534,6 +534,9 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             }
         } finally {
             close()
+            // If before calling disconnect() the state was not Connected (i.e. Connecting),
+            // the state at this point will be Disconnecting. Change it to Disconnected manually.
+            _state.compareAndSet(ConnectionState.Disconnecting, ConnectionState.Disconnected())
             logger.info("Disconnected from {}", this)
         }
     }


### PR DESCRIPTION
If a device was connecting with `AutoConnect` and was in `Connecting` state and the `disconnect()` method was called, the state changed to `Disconnecting` but not to `Disconnected`, as there was no GATT event afterwards that would change the state.

This PR changes from `Disconnecting` to `Disconnected` after `disconnect()` is called.

Also, a `CancellationException` is now propagated up to the app if it happens during or before MTU request.