### PR TITLE
Operation locks added to other GATT operations

### DIFF
--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -62,6 +62,7 @@ import no.nordicsemi.kotlin.ble.client.exception.ConnectionFailedException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.PeripheralNotConnectedException
 import no.nordicsemi.kotlin.ble.client.exception.ValueDoesNotMatchException
+import no.nordicsemi.kotlin.ble.client.internal.OperationMutex
 import no.nordicsemi.kotlin.ble.core.ATT_MTU_DEFAULT
 import no.nordicsemi.kotlin.ble.core.ATT_MTU_MAX
 import no.nordicsemi.kotlin.ble.core.BondState
@@ -432,19 +433,21 @@ open class Peripheral(
         check(isConnected) {
             throw PeripheralNotConnectedException()
         }
-        logger.trace("Reading PHY")
-        return impl.events
-            .onSubscription {
-                if (!impl.readPhy()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        return OperationMutex.withLock {
+            logger.trace("Reading PHY")
+            impl.events
+                .onSubscription {
+                    if (!impl.readPhy()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(PhyChanged::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.phy
-            ?.also { logger.info("PHY read: {}", it) }
-            ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(PhyChanged::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.phy
+                ?.also { logger.info("PHY read: {}", it) }
+                ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**
@@ -473,19 +476,21 @@ open class Peripheral(
         check(isConnected) {
             throw PeripheralNotConnectedException()
         }
-        logger.trace("Setting preferred PHY: tx={}, rx={}, options={}", txPhy, rxPhy, phyOptions)
-        return impl.events
-            .onSubscription {
-                if (!impl.requestPhy(txPhy, rxPhy, phyOptions)) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        return OperationMutex.withLock {
+            logger.trace("Setting preferred PHY: tx={}, rx={}, options={}", txPhy, rxPhy, phyOptions)
+            impl.events
+                .onSubscription {
+                    if (!impl.requestPhy(txPhy, rxPhy, phyOptions)) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(PhyChanged::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.phy
-            ?.also { logger.info("PHY changed to: {}", it) }
-            ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(PhyChanged::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.phy
+                ?.also { logger.info("PHY changed to: {}", it) }
+                ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**
@@ -547,19 +552,21 @@ open class Peripheral(
             return
         }
         mtuRequested = true
-        logger.trace("Requesting MTU: {}", ATT_MTU_MAX)
-        impl.events
-            .onSubscription {
-                if (!impl.requestMtu(ATT_MTU_MAX)) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        OperationMutex.withLock {
+            logger.trace("Requesting MTU: {}", ATT_MTU_MAX)
+            impl.events
+                .onSubscription {
+                    if (!impl.requestMtu(ATT_MTU_MAX)) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(MtuChanged::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.mtu
-            ?.also { logger.info("MTU set to {}", it) }
-            ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(MtuChanged::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.mtu
+                ?.also { logger.info("MTU set to {}", it) }
+                ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**
@@ -582,19 +589,21 @@ open class Peripheral(
         check(isConnected) {
             throw PeripheralNotConnectedException()
         }
-        logger.trace("Requesting connection priority: {}", priority)
-        return impl.events
-            .onSubscription {
-                if (!impl.requestConnectionPriority(priority)) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        return OperationMutex.withLock {
+            logger.trace("Requesting connection priority: {}", priority)
+            impl.events
+                .onSubscription {
+                    if (!impl.requestConnectionPriority(priority)) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(ConnectionParametersChanged::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.newParameters
-            ?.also { logger.info("Connection parameters updated: {}", it) }
-            ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(ConnectionParametersChanged::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.newParameters
+                ?.also { logger.info("Connection parameters updated: {}", it) }
+                ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**
@@ -645,25 +654,27 @@ open class Peripheral(
             logger.warn("Reliable write not in progress, nothing to execute")
             return
         }
-        logger.trace("Executing reliable write")
-        impl.events
-            .onSubscription {
-                if (!impl.executeReliableWrite()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
-                }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(ReliableWriteCompleted::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.let {
-                when (it.status) {
-                    OperationStatus.SUCCESS -> logger.info("Reliable write executed successfully")
-                    else -> {
-                        logger.warn("Reliable write failed: {}", it.status)
-                        throw OperationFailedException(it.status)
+        OperationMutex.withLock {
+            logger.trace("Executing reliable write")
+            impl.events
+                .onSubscription {
+                    if (!impl.executeReliableWrite()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
                     }
                 }
-            } ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(ReliableWriteCompleted::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.let {
+                    when (it.status) {
+                        OperationStatus.SUCCESS -> logger.info("Reliable write executed successfully")
+                        else -> {
+                            logger.warn("Reliable write failed: {}", it.status)
+                            throw OperationFailedException(it.status)
+                        }
+                    }
+                } ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**
@@ -685,25 +696,27 @@ open class Peripheral(
             logger.warn("Reliable write not in progress, nothing to abort")
             return
         }
-        logger.trace("Aborting reliable write")
-        impl.events
-            .onSubscription {
-                if (!impl.abortReliableWrite()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
-                }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(ReliableWriteCompleted::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.let {
-                when (it.status) {
-                    OperationStatus.SUCCESS -> logger.info("Reliable write aborted successfully")
-                    else -> {
-                        logger.warn("Aborting reliable write failed: {}", it.status)
-                        throw OperationFailedException(it.status)
+        OperationMutex.withLock {
+            logger.trace("Aborting reliable write")
+            impl.events
+                .onSubscription {
+                    if (!impl.abortReliableWrite()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
                     }
                 }
-            } ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(ReliableWriteCompleted::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.let {
+                    when (it.status) {
+                        OperationStatus.SUCCESS -> logger.info("Reliable write aborted successfully")
+                        else -> {
+                            logger.warn("Aborting reliable write failed: {}", it.status)
+                            throw OperationFailedException(it.status)
+                        }
+                    }
+                } ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**
@@ -732,16 +745,18 @@ open class Peripheral(
         check(!impl.isClosed) {
             throw PeripheralClosedException()
         }
-        logger.trace("Refreshing cache")
-        impl.events
-            .onSubscription {
-                if (!impl.refreshCache()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        OperationMutex.withLock {
+            logger.trace("Refreshing cache")
+            impl.events
+                .onSubscription {
+                    if (!impl.refreshCache()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            // TODO add .timeout(...)?
-            .first { it == ServicesChanged }
-            .also { logger.info("Cache refreshed") }
+                // TODO add .timeout(...)?
+                .first { it == ServicesChanged }
+                .also { logger.info("Cache refreshed") }
+        }
     }
 
     /**
@@ -755,28 +770,32 @@ open class Peripheral(
         if (hasBondInformation) {
             return
         }
-        logger.trace("Creating bond")
-        impl.bondState
-            .onSubscription {
-                if (!impl.createBond()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
-                }
-            }
-            // Skip the initial state. It should transition to BONDING quickly.
-            .dropWhile { it == BondState.NONE }
-            // Now, await for the next state after BONDING.
-            .first { it != BondState.BONDING }
-            // And process it.
-            .also {
-                when (it) {
-                    BondState.BONDED -> logger.info("Bond created")
-                    BondState.NONE -> {
-                        logger.warn("Bonding failed")
-                        throw BondingFailedException()
+        OperationMutex.withLock {
+            logger.trace("Creating bond")
+            impl.bondState
+                .onSubscription {
+                    if (!impl.createBond()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
                     }
-                    else -> { /* Not possible */ }
                 }
-            }
+                // Skip the initial state. It should transition to BONDING quickly.
+                .dropWhile { it == BondState.NONE }
+                // Now, await for the next state after BONDING.
+                .first { it != BondState.BONDING }
+                // And process it.
+                .also {
+                    when (it) {
+                        BondState.BONDED -> logger.info("Bond created")
+                        BondState.NONE -> {
+                            logger.warn("Bonding failed")
+                            throw BondingFailedException()
+                        }
+
+                        else -> { /* Not possible */
+                        }
+                    }
+                }
+        }
     }
 
     /**
@@ -791,15 +810,17 @@ open class Peripheral(
         if (!hasBondInformation) {
             return
         }
-        logger.trace("Removing bond information")
-        impl.bondState
-            .onSubscription {
-                if (!impl.removeBond()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        OperationMutex.withLock {
+            logger.trace("Removing bond information")
+            impl.bondState
+                .onSubscription {
+                    if (!impl.removeBond()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            .first { it == BondState.NONE }
-            .also { logger.info("Bond information removed") }
+                .first { it == BondState.NONE }
+                .also { logger.info("Bond information removed") }
+        }
     }
 
     /**

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.PeripheralNotConnectedException
+import no.nordicsemi.kotlin.ble.client.internal.OperationMutex
 import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.Peer
@@ -334,6 +335,13 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
         _services.value?.onEach { it.owner = null }
         _services.update { null }
         servicesDiscovered = false
+        if (OperationMutex.holdsLock(ServicesChanged)) {
+            try {
+                OperationMutex.unlock(ServicesChanged)
+            } catch (e: IllegalStateException) {
+                logger.warn(e.message)
+            }
+        }
         // Note!
         // Don't clear the serviceDiscoveryRequested flag here.
         // It will be cleared when the peripheral is closed.
@@ -376,6 +384,12 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             }
 
             is ServicesDiscovered -> {
+                try {
+                    // Unlocks the lock locked in `discoverServices` below.
+                    OperationMutex.unlock(ServicesChanged)
+                } catch (e: IllegalStateException) {
+                    logger.warn(e.message)
+                }
                 if (event.services.isEmpty()) {
                     logger.warn("Service discovery failed")
                     invalidateServices()
@@ -413,8 +427,17 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
     private fun discoverServices(uuids: List<Uuid>) {
         if (!servicesDiscovered) {
             servicesDiscovered = true
-            logger.trace("Discovering services")
             scope.launch {
+                try {
+                    // On older Android versions each Bluetooth operation needs to await its
+                    // callback before another one can be triggered. Otherwise, some callbacks
+                    // aren't called at all. I.e. discovering services while also requesting HIGH
+                    // connection priority makes only one of them to complete.
+                    OperationMutex.lock(ServicesChanged)
+                } catch (e: IllegalStateException) {
+                    logger.warn(e.message)
+                }
+                logger.trace("Discovering services")
                 impl.discoverServices(uuids)
             }
         }
@@ -508,19 +531,21 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
         check (isConnected) {
             throw PeripheralNotConnectedException()
         }
-        logger.trace("Reading RSSI")
-        return impl.events
-            .onSubscription {
-                if (!impl.readRssi()) {
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+        return OperationMutex.withLock {
+            logger.trace("Reading RSSI")
+            impl.events
+                .onSubscription {
+                    if (!impl.readRssi()) {
+                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    }
                 }
-            }
-            .takeWhile { !it.isDisconnectionEvent }
-            .filterIsInstance(RssiRead::class)
-            // TODO add .timeout(...)?
-            .firstOrNull()?.rssi
-            ?.also { logger.info("RSSI read: {} dBm", it) }
-            ?: throw PeripheralNotConnectedException()
+                .takeWhile { !it.isDisconnectionEvent }
+                .filterIsInstance(RssiRead::class)
+                // TODO add .timeout(...)?
+                .firstOrNull()?.rssi
+                ?.also { logger.info("RSSI read: {} dBm", it) }
+                ?: throw PeripheralNotConnectedException()
+        }
     }
 
     /**

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/OperationMutex.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/OperationMutex.kt
@@ -31,16 +31,58 @@
 
 package no.nordicsemi.kotlin.ble.client.internal
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
  * This mutex ensures that only one Bluetooth LE operation can be executed concurrently.
  */
-internal object OperationMutex {
+object OperationMutex {
     private val lock = Mutex(locked = false)
 
-    suspend fun <T> withLock(block: suspend () -> T): T {
-        return lock.withLock { block() }
+    /**
+     * Executes the given action under this mutex's lock.
+     *
+     * @param owner - Optional owner token for debugging. When owner is specified (non-null value)
+     * and this mutex is already locked with the same token (same identity),
+     * this function throws [IllegalStateException].
+     * @param block - The action to execute under the mutex's lock
+     */
+    suspend fun <T> withLock(owner: Any? = null, block: suspend () -> T): T {
+        return lock.withLock(owner) { block() }
+    }
+
+    /**
+     * Locks this mutex, suspending caller until the lock is acquired (in other words, while the
+     * lock is held elsewhere).
+     *
+     *
+     * This suspending function is cancellable: if the Job of the current coroutine is cancelled
+     * while this suspending function is waiting, this function immediately resumes with
+     * [CancellationException].
+     */
+    suspend fun lock(owner: Any? = null) {
+        lock.lock(owner)
+    }
+
+    /**
+     * Unlocks this mutex.
+     *
+     * Throws [IllegalStateException] if invoked on a mutex that is not locked or was locked with
+     * a different owner token (by identity).
+     */
+    fun unlock(owner: Any? = null) {
+        lock.unlock(owner)
+    }
+
+    /**
+     * Checks whether this mutex is locked by the specified owner.
+     *
+     * @param owner - The owner token to check.
+     * @return `true` if this mutex is locked by the given owner.
+     */
+    fun holdsLock(owner: Any): Boolean {
+        return lock.holdsLock(owner)
     }
 }


### PR DESCRIPTION
It has been observed, that older Android devices work more reliable when each operation awaits for the end of the previous one. I.e. service discovery requested in paralell with requesting high connection priority will finish only one of them.

This PR adds locks around each operation to ensure they are executed one after another.