### PR TITLE
[Breaking] Client API improvements

### DIFF
--- a/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockExecutor.kt
+++ b/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockExecutor.kt
@@ -36,6 +36,7 @@ package no.nordicsemi.kotlin.ble.client.android.mock.internal
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withTimeout
 import no.nordicsemi.kotlin.ble.android.mock.MockEnvironment
 import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
@@ -48,6 +49,7 @@ import no.nordicsemi.kotlin.ble.core.PeripheralType
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PhyOption
 import org.jetbrains.annotations.Range
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * A mock implementation of [Peripheral] for Android.
@@ -73,6 +75,19 @@ open class MockExecutor(
     override val bondState = _bondState.asStateFlow()
 
     // Implementation
+
+    override suspend fun connect(autoConnect: Boolean, preferredPhy: List<Phy>) {
+        if (autoConnect) {
+            // There is no timeout for auto connect attempts.
+            super.connect(true, preferredPhy)
+        } else {
+            // Android has a timeout of 30 seconds for connection attempts.
+            // User may set a shorter timeout in ConnectionOptions.Direct.
+            withTimeout(30.seconds) {
+                super.connect(false, preferredPhy)
+            }
+        }
+    }
 
     override suspend fun createBond(): Boolean {
         TODO("Not yet implemented")

--- a/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockExecutor.kt
+++ b/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockExecutor.kt
@@ -177,33 +177,33 @@ open class MockExecutor(
         return true
     }
 
-    private fun ConnectionPriority.toConnectionParameters(environment: MockEnvironment): ConnectionParameters.Connected = when (this) {
-        ConnectionPriority.BALANCED -> ConnectionParameters.Connected(
+    private fun ConnectionPriority.toConnectionParameters(environment: MockEnvironment): ConnectionParameters.Specified = when (this) {
+        ConnectionPriority.BALANCED -> ConnectionParameters.Specified(
             connectionInterval = 24,
-            slaveLatency = 0,
+            latency = 0,
             supervisionTimeout = if (environment.androidSdkVersion >= MockEnvironment.AndroidSdkVersion.OREO) 500 else 2000
         )
         ConnectionPriority.HIGH -> if (environment.androidSdkVersion >= MockEnvironment.AndroidSdkVersion.MARSHMALLOW) {
-            ConnectionParameters.Connected(
+            ConnectionParameters.Specified(
                 connectionInterval = 9,
-                slaveLatency = 0,
+                latency = 0,
                 supervisionTimeout = if (environment.androidSdkVersion >= MockEnvironment.AndroidSdkVersion.OREO) 500 else 2000
             )
         } else {
-            ConnectionParameters.Connected(
+            ConnectionParameters.Specified(
                 connectionInterval = 6,
-                slaveLatency = 0,
+                latency = 0,
                 supervisionTimeout = 2000
             )
         }
-        ConnectionPriority.LOW_POWER -> ConnectionParameters.Connected(
+        ConnectionPriority.LOW_POWER -> ConnectionParameters.Specified(
             connectionInterval = 80,
-            slaveLatency = 2,
+            latency = 2,
             supervisionTimeout = if (environment.androidSdkVersion >= MockEnvironment.AndroidSdkVersion.OREO) 500 else 2000
         )
-        ConnectionPriority.DIGITAL_CAR_KEY -> ConnectionParameters.Connected(
+        ConnectionPriority.DIGITAL_CAR_KEY -> ConnectionParameters.Specified(
             connectionInterval = 24,
-            slaveLatency = 0,
+            latency = 0,
             supervisionTimeout = 500
         )
     }

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
@@ -44,13 +44,13 @@ import androidx.core.util.forEach
 import no.nordicsemi.kotlin.ble.client.android.AdvertisingData
 import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
-import no.nordicsemi.kotlin.ble.core.PeripheralType
 import no.nordicsemi.kotlin.ble.client.android.ScanResult
 import no.nordicsemi.kotlin.ble.client.android.exception.ScanningFailedToStartException
 import no.nordicsemi.kotlin.ble.core.BondState
 import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.Manager
 import no.nordicsemi.kotlin.ble.core.OperationStatus
+import no.nordicsemi.kotlin.ble.core.PeripheralType
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PhyOption
 import no.nordicsemi.kotlin.ble.core.PrimaryPhy

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -213,7 +213,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
             logger.warn("Connection update failed with status $status")
             // no return, event must be emitted
         }
-        val newParameters = ConnectionParameters.Connected(interval, latency, timeout)
+        val newParameters = ConnectionParameters.Specified(interval, latency, timeout)
         logger.debug("onConnectionUpdated: {}", newParameters)
         _events.tryEmit(ConnectionParametersChanged(newParameters))
     }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -361,7 +361,7 @@ open class Peripheral(
                                     // The connection timeout should behave just as a timeout defined
                                     // by the user with withTimeout or Direct(timeout=...).
                                     withTimeout(0) {}
-                                    // ^ throws TimeoutCancellationException!!!
+                                    // ^ throws TimeoutCancellationException("Timed out immediately")!!!
                                 }
                             }
                             check(options.retry > 0) {

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -360,8 +360,8 @@ open class Peripheral(
                         else -> {}
                     }
                 } catch (e: TimeoutCancellationException) {
-                    logger.warn("Connection attempt timed out after {}", options.timeout)
-                    _state.update { ConnectionState.Disconnected(Reason.Timeout(options.timeout)) }
+                    logger.warn("Connection attempt timed out after {}", e.timeout)
+                    _state.update { ConnectionState.Disconnected(Reason.Timeout(e.timeout ?: options.timeout)) }
                     close()
                     throw e
                 } catch (e: CancellationException) {

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withTimeout
 import no.nordicsemi.kotlin.ble.client.ConnectionParametersChanged
 import no.nordicsemi.kotlin.ble.client.ConnectionStateChanged
 import no.nordicsemi.kotlin.ble.client.GattEvent
@@ -323,6 +324,7 @@ open class Peripheral(
 
             // Direct connection gives more options to configure the connection.
             is CentralManager.ConnectionOptions.Direct -> {
+                val now = System.currentTimeMillis()
                 try {
                     val state = await(
                         action = { impl.connect(false, options.preferredPhy) },
@@ -346,8 +348,23 @@ open class Peripheral(
                             initiateConnection()
                         }
                         is ConnectionState.Disconnected -> {
+                            val reason = state.reason!!
+                            // A connection may timeout for 3 reasons: Direct(timeout), withTimeout,
+                            // or internal timeout (error 133/147 after ~30s). The library should
+                            // report all 3 cases the same way: as a TimeoutCancellationException.
+                            // Error 147 was added in API 35: https://developer.android.com/reference/android/bluetooth/BluetoothGatt#GATT_CONNECTION_TIMEOUT
+                            // Before, a connection timeout was reported as error 133.
+                            if (reason is Reason.Unknown && (reason.status == 133 || reason.status == 147)) {
+                                val elapsed = System.currentTimeMillis() - now
+                                // Default timeout for direct connection is 30 seconds. Let's use 25.
+                                if (elapsed >= 25000) {
+                                    // The connection timeout should behave just as a timeout defined
+                                    // by the user with withTimeout or Direct(timeout=...).
+                                    withTimeout(0) {}
+                                    // ^ throws TimeoutCancellationException!!!
+                                }
+                            }
                             check(options.retry > 0) {
-                                val reason = state.reason!!
                                 logger.warn("Connection attempt failed (reason: {})", reason)
                                 _state.update { state }
                                 throw ConnectionFailedException(reason)
@@ -360,8 +377,9 @@ open class Peripheral(
                         else -> {}
                     }
                 } catch (e: TimeoutCancellationException) {
-                    logger.warn("Connection attempt timed out after {}", e.timeout)
-                    _state.update { ConnectionState.Disconnected(Reason.Timeout(e.timeout ?: options.timeout)) }
+                    val elapsed = System.currentTimeMillis() - now
+                    logger.warn("Connection attempt timed out after {}", e.timeout ?: elapsed.milliseconds)
+                    _state.update { ConnectionState.Disconnected(Reason.Timeout(e.timeout ?: elapsed.milliseconds)) }
                     close()
                     throw e
                 } catch (e: CancellationException) {

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -327,7 +327,7 @@ private class StubRemoteCharacteristic(
         else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
     }
 
-    override suspend fun subscribe(): Flow<ByteArray> = when {
+    override fun subscribe(): Flow<ByteArray> = when {
         owner == null -> throw InvalidAttributeException()
         isSubscribable() -> _value.filter { _isNotifying }
         else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -40,7 +40,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import no.nordicsemi.kotlin.ble.client.AnyRemoteService
 import no.nordicsemi.kotlin.ble.client.ConnectionParametersChanged
@@ -79,6 +80,8 @@ import no.nordicsemi.kotlin.ble.core.internal.CharacteristicDefinition
 import no.nordicsemi.kotlin.ble.core.internal.DescriptorDefinition
 import no.nordicsemi.kotlin.ble.core.internal.ServerScopeImpl
 import no.nordicsemi.kotlin.ble.core.internal.ServiceDefinition
+import no.nordicsemi.kotlin.ble.core.util.MergeResult
+import no.nordicsemi.kotlin.ble.core.util.mergeIndexed
 import org.jetbrains.annotations.Range
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -327,13 +330,24 @@ private class StubRemoteCharacteristic(
         else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
     }
 
-    override fun subscribe(): Flow<ByteArray> = when {
+    override fun subscribe(): Flow<ByteArray> = subscribe {}
+
+    override suspend fun waitForValueChange(
+        rawDataFilter: (ByteArray) -> Boolean,
+        merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
+        filter: (ByteArray) -> Boolean,
+        trigger: suspend RemoteCharacteristic.() -> Unit,
+    ): ByteArray = subscribe(trigger)
+        .filter(rawDataFilter)
+        .mergeIndexed(merge)
+        .firstOrNull(filter)
+        ?: throw InvalidAttributeException()
+
+    private fun subscribe(trigger: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> = when {
         owner == null -> throw InvalidAttributeException()
-        isSubscribable() -> _value.filter { _isNotifying }
+        isSubscribable() -> _value.filter { _isNotifying }.onStart { trigger() }
         else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
     }
-
-    override suspend fun waitForValueChange(): ByteArray = subscribe().first()
 
     override fun toString(): String = uuid.toString()
 }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -148,7 +148,7 @@ private class StubExecutor(
     }
 
     override suspend fun requestConnectionPriority(priority: ConnectionPriority): Boolean {
-        _events.emit(ConnectionParametersChanged(ConnectionParameters.Connected(15, 0, 0)))
+        _events.emit(ConnectionParametersChanged(ConnectionParameters.Specified(15, 0, 0)))
         return true
     }
 

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteCharacteristic.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteCharacteristic.kt
@@ -167,7 +167,7 @@ class PreviewRemoteCharacteristic : RemoteCharacteristic {
 
     override suspend fun write(data: ByteArray, writeType: WriteType) {}
 
-    override suspend fun subscribe(): Flow<ByteArray> = emptyFlow()
+    override fun subscribe(): Flow<ByteArray> = emptyFlow()
 
     override suspend fun waitForValueChange(): ByteArray = byteArrayOf()
 }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteCharacteristic.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteCharacteristic.kt
@@ -43,6 +43,7 @@ import no.nordicsemi.kotlin.ble.core.CharacteristicScope
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.internal.CharacteristicDefinition
 import no.nordicsemi.kotlin.ble.core.internal.ServerScopeImpl
+import no.nordicsemi.kotlin.ble.core.util.MergeResult
 import no.nordicsemi.kotlin.ble.core.util.fromShortUuid
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -169,5 +170,11 @@ class PreviewRemoteCharacteristic : RemoteCharacteristic {
 
     override fun subscribe(): Flow<ByteArray> = emptyFlow()
 
-    override suspend fun waitForValueChange(): ByteArray = byteArrayOf()
+    override suspend fun waitForValueChange(
+        rawDataFilter: (ByteArray) -> Boolean,
+        merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
+        filter: (ByteArray) -> Boolean,
+        trigger: suspend RemoteCharacteristic.() -> Unit,
+    ): ByteArray = byteArrayOf()
+        .also { trigger() }
 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -472,6 +472,8 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * @param uuids An optional list of service UUID to filter the results. If empty, all services
      *        will be returned. Some platforms may do partial service discovery and return only
      *        services with given UUIDs.
+     * @return A state flow with the list of services, or `null` if the device is not connected,
+     * or the services have been invalidated.
      */
     @OptIn(ExperimentalUuidApi::class)
     fun services(uuids: List<Uuid> = emptyList()): StateFlow<List<RemoteService>?> {

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
@@ -41,6 +41,10 @@ import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import no.nordicsemi.kotlin.ble.core.Characteristic
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.defaultWriteType
+import no.nordicsemi.kotlin.ble.core.util.MergeResult
+import no.nordicsemi.kotlin.ble.core.util.chunked
+import no.nordicsemi.kotlin.ble.core.util.merge
+import no.nordicsemi.kotlin.ble.core.util.mergeIndexed
 
 /**
  * A GATT characteristic of a service on a remote connected peripheral device.
@@ -57,11 +61,17 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
 
     /**
      * Returns whether the characteristic is notifying or indicating.
+     *
+     * Use [subscribe] or [waitForValueChange] to subscribe for value changes, or
+     * [setNotifying] to enable or disable notifications or indications manually.
      */
     val isNotifying: Boolean
 
     /**
-     * Sets notifications or indications state, depending on the characteristic's properties.
+     * Enables notifications or indications, depending on the characteristic's properties.
+     *
+     * This method writes to the Client Characteristic Configuration Descriptor (CCCD)
+     * belonging to this characteristic to enable or disable notifications or indications.
      *
      * Note, that calling [subscribe] or [waitForValueChange] will enable notifications
      * automatically.
@@ -69,30 +79,69 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * ### Possible race condition
      * If a device is expected to send a notification or indication right after enabling it,
      * there is a risk of missing it. In such cases, it is recommended to use [subscribe] or
-     * [waitForValueChange] instead, which subscribe to incoming messages before enabling
-     * notifications or indications on the peripheral.
+     * [waitForValueChange] before (or instead) calling this method, which subscribes to incoming
+     * messages before enabling them on the peripheral.
      *
+     * ### Example
+     * ```kotlin
+     * remoteCharacteristic.subscribe()
+     *    .onEach { data ->
+     *       // Handle the received data.
+     *    }
+     *    .launchIn(scope)
+     *
+     * // Note, that subscribe() enables notifications on terminal operator (collect, first, etc.).
+     * println("Notifications are enabled: ${remoteCharacteristic.isNotifying}") // -> false
+     *
+     * // Calling setNotifying(true) here ensures that notifications are enabled synchronically.
+     * // When this method returns, notifications are enabled and the characteristic
+     * // is ready to use.
+     * remoteCharacteristic.setNotifying(true)
+     * println("Notifications are enabled: ${remoteCharacteristic.isNotifying}") // -> true
+     * ```
+     * @param enabled True to enable notifications or indications, false to disable them.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the characteristic has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      */
     suspend fun setNotifying(enabled: Boolean)
 
     /**
      * Reads the value of the characteristic.
      *
+     * This method suspends until the value is read from the peripheral. Long Read procedure
+     * will be used automatically if the value is longer than the MTU.
+     *
+     * ### Example
+     * ```kotlin
+     * val value: ByteArray = remoteCharacteristic.read()
+     * ```
+     *
      * @return The value of the characteristic.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the characteristic has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      */
     suspend fun read(): ByteArray
 
     /**
      * Writes the value of the characteristic.
      *
+     * If [data] is longer than [Peripheral.maximumWriteValueLength] for given [writeType],
+     * the value will be trimmed. To write longer values, [chunked] them and write
+     * subsequent chunks.
+     *
+     * ```kotlin
+     * val data: ByteArray = // ...
+     * val maxLength = peripheral.maximumWriteValueLength(WriteType.WITHOUT_RESPONSE)
+     * data.chunked(maxLength).forEach { chunk ->
+     *     remoteCharacteristic.write(chunk, WriteType.WITHOUT_RESPONSE)
+     * }
+     * ```
      * @param data The data to be written.
      * @param writeType The write type to be used. By default set to the characteristic's
      * default write type based on its properties.
@@ -100,8 +149,9 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * procedure and the value replied back by the peripheral does not match the value written.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the characteristic has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      */
     suspend fun write(
         data: ByteArray,
@@ -111,18 +161,50 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
     /**
      * Subscribes for notifications or indications of the characteristic.
      *
-     * If not already enabled, this method will enable notifications or indications automatically
-     * on subscription.
+     * If not already enabled, this method enables notifications or indications automatically
+     * on subscription, that is when a terminal operator (`collect`, `first`, etc.) is invoked on
+     * the returned flow.
      *
-     * The client will NOT unsubscribe when the flow is closed.
-     * Use [setNotifying] to disable notifications or indications.
+     * It is safe to call [setNotify(true)][setNotifying] after calling this method to
+     * synchronically enable notifications on the peripheral before the flow starts getting collected.
      *
+     * If higher-level packets are sent as multiple notifications or indications, they may be
+     * merged using [merge] or [mergeIndexed] operator.
+     *
+     * ```kotlin
+     * remoteCharacteristic.subscribe()
+     *    // If a packet is split into multiple notifications, merge them.
+     *    .merge { accumulated, received ->
+     *        // [...]
+     *    }
+     *    // Transform the response raw data to a meaningful value.
+     *    .map { bytes -> parse(bytes) }
+     *    .onEach { data ->
+     *       // [...]
+     *    }
+     *    .launchIn(scope)
+     * // Optional: Enable notifications
+     * remoteCharacteristic.setNotifying(true)
+     * // Now the flow is collecting and notifications are enabled.
+     * ```
+     * This way no notification or indication will be missed and it is clear when the characteristic
+     * is ready (connected, subscribed, triggered to send data).
+     *
+     * If [setNotifying] is skipped, it will be called automatically when the flow collection starts.
+     *
+     * @return A flow emitting the raw data of notifications or indications sent from the
+     * characteristic when the value changes. The flow completes when the characteristic
+     * is invalidated, e.g., when the peripheral disconnects, or sends a Service Changed event.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the characteristic has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      * @see isNotifying
      * @see setNotifying
+     * @see waitForValueChange
+     * @see merge
+     * @see mergeIndexed
      */
     fun subscribe(): Flow<ByteArray>
 
@@ -130,17 +212,72 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * Waits for the value of the characteristic to change.
      *
      * This method suspends until the value of the characteristic changes.
-     * If the notifications are not enabled, it will enable them automatically.
-     * Use [setNotifying] to disable notifications or indications.
+     * If the notifications or indications are not enabled, this method will enable them
+     * automatically after subscribing for value changes.
      *
-     * @return The new value of the characteristic.
+     * ```kotlin
+     * val newValue = remoteCharacteristic.waitForValueChange(
+     *   trigger = {
+     *       // Write to the characteristic to request new data.
+     *       write(byteArrayOf(0x01))
+     *       // Note: You may also write to other characteristics or descriptors here:
+     *       // anotherCharacteristic.write(byteArrayOf(0x02))
+     *   },
+     *   rawDataFilter = { data ->
+     *       // Accept only packets starting with 0xAA.
+     *       data.isNotEmpty() && data[0] == 0xAA.toByte()
+     *   },
+     *   merge = { accumulator, received, index ->
+     *       // Assume the first byte indicates the total length of the message.
+     *       val expectedLength = if (index == 0) received[1].toInt() else accumulator[1].toInt()
+     *       val newAccumulator = accumulator + received
+     *       if (newAccumulator.size - 2 < expectedLength) {
+     *           // More data expected.
+     *           MergeResult.Accumulate(newAccumulator)
+     *       } else {
+     *           // Full message received.
+     *           MergeResult.Completed(newAccumulator.drop(2)) // Drop the header.
+     *       }
+     *   },
+     *   filter = { merged ->
+     *       // Accept only messages with a valid checksum.
+     *       val checksum = merged.last()
+     *       val calculated = merged.dropLast(1).fold(0.toByte()) { acc, byte -> acc + byte }
+     *       checksum == calculated
+     *   }
+     * )
+     * var response = parse(newValue)
+     * ```
+     *
+     * @param rawDataFilter An optional filter function to evaluate the received notification or
+     * indication. Accepted packets will be sent to merge [merge] operator for further processing.
+     * By default, all received data is accepted.
+     * @param merge Ao optional merge function to combine multiple received values into one.
+     * This method can accumulate received values by returning [MergeResult.Accumulate] until a
+     * complete message is formed, which is then returned as [MergeResult.Completed].
+     * By default, each received value is treated as a complete message.
+     * @param filter An optional filter function to evaluate the merged value. When the function
+     * returns true, the value is returned from this method.
+     * @return The received value of the characteristic.
+     * @param trigger An optional trigger that will be executed once before waiting for the value change.
+     * It can be used to perform an action that may cause the peripheral to send a notification or
+     * indication, e.g., writing to the characteristic to request data. The [trigger] is executed
+     * in the context of the [RemoteCharacteristic], so its methods and properties can be accessed
+     * directly.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the characteristic has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      * @see subscribe
      * @see isNotifying
      * @see setNotifying
      */
-    suspend fun waitForValueChange(): ByteArray
+    suspend fun waitForValueChange(
+        rawDataFilter: ((ByteArray) -> Boolean) = { true },
+        merge: suspend (accumulator: ByteArray, received: ByteArray, index: Int) -> MergeResult =
+            { _, rec, _ -> MergeResult.Completed(rec) },
+        filter: ((ByteArray) -> Boolean) = { true },
+        trigger: suspend RemoteCharacteristic.() -> Unit = {},
+    ): ByteArray
 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
@@ -63,8 +63,14 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
     /**
      * Sets notifications or indications state, depending on the characteristic's properties.
      *
-     * Note, that calling [suspend] or [waitForValueChange] will enable notifications
+     * Note, that calling [subscribe] or [waitForValueChange] will enable notifications
      * automatically.
+     *
+     * ### Possible race condition
+     * If a device is expected to send a notification or indication right after enabling it,
+     * there is a risk of missing it. In such cases, it is recommended to use [subscribe] or
+     * [waitForValueChange] instead, which subscribe to incoming messages before enabling
+     * notifications or indications on the peripheral.
      *
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the characteristic has been invalidated due to
@@ -105,7 +111,8 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
     /**
      * Subscribes for notifications or indications of the characteristic.
      *
-     * This method suspends until the notifications are enabled.
+     * If not already enabled, this method will enable notifications or indications automatically
+     * on subscription.
      *
      * The client will NOT unsubscribe when the flow is closed.
      * Use [setNotifying] to disable notifications or indications.
@@ -117,7 +124,7 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * @see isNotifying
      * @see setNotifying
      */
-    suspend fun subscribe(): Flow<ByteArray>
+    fun subscribe(): Flow<ByteArray>
 
     /**
      * Waits for the value of the characteristic to change.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteDescriptor.kt
@@ -57,8 +57,9 @@ interface RemoteDescriptor: Descriptor {
      * @return The value of the descriptor.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the descriptor has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      */
     suspend fun read(): ByteArray
 
@@ -70,8 +71,9 @@ interface RemoteDescriptor: Descriptor {
      * procedure and the value replied back by the peripheral does not match the value written.
      * @throws OperationFailedException if the operation failed.
      * @throws InvalidAttributeException if the descriptor has been invalidated due to
-     * disconnection of service change event.
-     * @throws BluetoothException if the implementation fails, see cause for a reason.
+     * disconnection or service change event.
+     * @throws BluetoothException if the implementation fails, see [BluetoothException.cause] for
+     * a reason.
      */
     suspend fun write(data: ByteArray)
 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -52,6 +52,8 @@ import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+import no.nordicsemi.kotlin.ble.core.util.MergeResult
+import no.nordicsemi.kotlin.ble.core.util.mergeIndexed
 import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
@@ -242,7 +244,27 @@ abstract class BaseRemoteCharacteristic(
         }
     }
 
-    final override fun subscribe(): Flow<ByteArray> {
+    final override fun subscribe(): Flow<ByteArray> = subscribe {}
+
+    override suspend fun waitForValueChange(
+        rawDataFilter: (ByteArray) -> Boolean,
+        merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
+        filter: (ByteArray) -> Boolean,
+        trigger: suspend RemoteCharacteristic.() -> Unit,
+    ): ByteArray {
+        // Check whether the characteristic wasn't invalidated.
+        require(owner != null) {
+            throw InvalidAttributeException()
+        }
+
+        return subscribe(trigger)
+            .filter(rawDataFilter)
+            .mergeIndexed(merge)
+            .firstOrNull(filter)
+            ?: throw InvalidAttributeException()
+    }
+
+    private fun subscribe(trigger: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> {
         // Check whether the characteristic wasn't invalidated.
         require(owner != null) {
             throw InvalidAttributeException()
@@ -254,22 +276,16 @@ abstract class BaseRemoteCharacteristic(
         }
 
         return events
-            .onSubscription { setNotifying(true) }
+            .onSubscription {
+                // First, make sure the notifications or indications are enabled.
+                setNotifying(true)
+                // Then, invoke the trigger to start the peripheral sending value changes.
+                trigger()
+            }
             .takeWhile { !it.isServiceInvalidatedEvent }
             .filterIsInstance(CharacteristicChanged::class)
             .filter { isNotifying && it.matches() }
             .map { it.value }
-    }
-
-    final override suspend fun waitForValueChange(): ByteArray {
-        // Check whether the characteristic wasn't invalidated.
-        require(owner != null) {
-            throw InvalidAttributeException()
-        }
-
-        return subscribe()
-            .firstOrNull()
-            ?: throw InvalidAttributeException()
     }
 
     final override fun toString(): String = uuid.toString()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -242,7 +242,7 @@ abstract class BaseRemoteCharacteristic(
         }
     }
 
-    final override suspend fun subscribe(): Flow<ByteArray> {
+    final override fun subscribe(): Flow<ByteArray> {
         // Check whether the characteristic wasn't invalidated.
         require(owner != null) {
             throw InvalidAttributeException()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -158,7 +158,7 @@ abstract class BaseRemoteDescriptor(
         }
 
         // Verify that the descriptor can be written to.
-        require(isReadable()) {
+        require(isWritable()) {
             throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
         }
 

--- a/client-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -223,16 +223,16 @@ class PeripheralSpec<ID: Any> private constructor(
                 phy = Phy.PHY_LE_1M
                 mtu = 23
                 l2capMtu = 27
-                connectionParameters = ConnectionParameters.Connected(
+                connectionParameters = ConnectionParameters.Specified(
                     connectionInterval = preferredConnectionInterval!!.start,
-                    slaveLatency = preferredSlaveLatency!!,
+                    latency = preferredSlaveLatency!!,
                     supervisionTimeout = preferredSupervisionTimeout!!
                 )
             }
         }
 
     /** Current connection parameters. */
-    var connectionParameters: ConnectionParameters.Connected? = null
+    var connectionParameters: ConnectionParameters.Specified? = null
         private set
 
     /** Current ATT MTU. */
@@ -435,7 +435,7 @@ class PeripheralSpec<ID: Any> private constructor(
      * event with reason [ConnectionState.Disconnected.Reason.LinkLoss] after the supervision timeout.
      *
      * @param proximity The new proximity. Use [Proximity.OUT_OF_RANGE] to simulate leaving the range.
-     * @see ConnectionParameters.Connected.supervisionTimeout
+     * @see ConnectionParameters.Specified.supervisionTimeout
      */
     fun simulateProximityChange(proximity: Proximity) {
         this.proximity = proximity
@@ -499,7 +499,7 @@ class PeripheralSpec<ID: Any> private constructor(
      * Connected clients will receive a disconnection event with reason
      * [ConnectionState.Disconnected.Reason.LinkLoss] after the supervision timeout.
      *
-     * @see ConnectionParameters.Connected.supervisionTimeout
+     * @see ConnectionParameters.Specified.supervisionTimeout
      */
     fun simulateReset() {
         eventHandler?.onReset()
@@ -620,7 +620,7 @@ class PeripheralSpec<ID: Any> private constructor(
      * @param delay Number of old connection intervals to wait before applying new parameters.
      * Defaults to 5.
      */
-    fun simulateConnectionParametersRequest(parameters: ConnectionParameters.Connected, delay: Int = 5) {
+    fun simulateConnectionParametersRequest(parameters: ConnectionParameters.Specified, delay: Int = 5) {
         // TODO Validate parameters against preferred / possible parameters?
         connectionParameters?.connectionIntervalMillis?.let { connectionInterval ->
             scope.launch {
@@ -850,10 +850,10 @@ class PeripheralSpec<ID: Any> private constructor(
                     // Android changes connection parameters during service discovery.
                     if (environment.reportsConnectionParameters) {
                         _events.emit(ConnectionParametersChanged(
-                            ConnectionParameters.Connected(
+                            ConnectionParameters.Specified(
                                 connectionInterval = 6, // 7.5 ms
                                 // TODO Are those kept the same?
-                                slaveLatency = connectionParameters.supervisionTimeout,
+                                latency = connectionParameters.supervisionTimeout,
                                 supervisionTimeout = connectionParameters.supervisionTimeout,
                             )
                         ))
@@ -957,7 +957,7 @@ class PeripheralSpec<ID: Any> private constructor(
          * @param parameters The requested connection parameters.
          * @return `true` if the request was started, `false` otherwise.
          */
-        suspend fun requestConnectionParameters(parameters: ConnectionParameters.Connected): Boolean {
+        suspend fun requestConnectionParameters(parameters: ConnectionParameters.Specified): Boolean {
             val connectionParameters = connectionParameters ?: return false
 
             // On environments that report connection parameters update, simulate the delay

--- a/client-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -502,20 +502,16 @@ class PeripheralSpec<ID: Any> private constructor(
      * @see ConnectionParameters.Specified.supervisionTimeout
      */
     fun simulateReset() {
+        val supervisionTimeout = connectionParameters?.supervisionTimeoutMillis
+        connectionsCount = 0
         eventHandler?.onReset()
 
         // If the device was connected, notify about disconnection due to link loss.
-        connectionParameters?.supervisionTimeoutMillis?.let { supervisionTimeout ->
+        if (supervisionTimeout != null) {
             scope.launch {
                 // Simulate supervision timeout delay before notifying clients.
                 delay(supervisionTimeout)
-
-                // If clients still assume they are connected, notify them about link loss.
-                if (isConnected) {
-                    // TODO Should the connection be dropped immediately, or after supervision timeout? See proximity setter.
-                    connectionsCount = 0
-                    _events.emit(ConnectionStateChanged(ConnectionState.Disconnected(Reason.LinkLoss)))
-                }
+                _events.emit(ConnectionStateChanged(ConnectionState.Disconnected(Reason.LinkLoss)))
             }
         }
     }

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionParameters.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionParameters.kt
@@ -34,11 +34,61 @@
 package no.nordicsemi.kotlin.ble.core
 
 import org.jetbrains.annotations.Range
+import kotlin.time.Duration
 
 /**
  * Bluetooth LE connection parameters.
  */
 sealed class ConnectionParameters {
+
+    companion object {
+        /**
+         * Creates unknown connection parameters.
+         *
+         * @return Unknown connection parameters.
+         * @see ConnectionParameters.Unknown
+         */
+        operator fun invoke(): ConnectionParameters = Unknown
+
+        /**
+         * Creates a specified connection parameters.
+         *
+         * @param connectionInterval Connection interval in 1.25ms unit.
+         *        Valid range is from 6 (7.5ms) to 3200 (4000ms).
+         * @param latency Connection latency. Valid range is from 0 to 499.
+         * @param supervisionTimeout Supervision timeout in 10ms unit.
+         *        Valid range is from 10 (0.1s) to 3200 (32s)
+         * @return Specified connection parameters.
+         * @see ConnectionParameters.Specified
+         */
+        operator fun invoke(
+            connectionInterval: Int,
+            latency: Int,
+            supervisionTimeout: Int,
+        ) = Specified(
+            connectionInterval,
+            latency,
+            supervisionTimeout,
+        )
+        /**
+         * Creates a specified connection parameters.
+         *
+         * @param connectionInterval Connection interval.
+         * @param latency Connection latency.
+         * @param supervisionTimeout Supervision timeout.
+         * @return Specified connection parameters.
+         * @see ConnectionParameters.Specified
+         */
+        operator fun invoke(
+            connectionInterval: Duration,
+            latency: Int,
+            supervisionTimeout: Duration,
+        ) = Specified(
+            connectionInterval,
+            latency,
+            supervisionTimeout,
+        )
+    }
 
     /**
      * Connection parameters are not known due to API limitations, but the device is connected.
@@ -58,15 +108,7 @@ sealed class ConnectionParameters {
      * it is up to your application to decide how often you want the devices to communicate by setting
      * the connection interval.
      *
-     * ### Supervision timeout
-     *
-     * When two devices are connected, they agree on a parameter that determines how long it should
-     * take since the last packet was successfully received until the devices consider the connection lost.
-     * This is called the supervision timeout. So if one of the devices is unexpectedly switched off,
-     * runs out of battery, or if the devices are out of radio range, then this is the amount of time
-     * it takes between successfully receiving the last packet before the connection is considered lost.
-     *
-     * ### Slave latency
+     * ### Connection latency
      *
      * Peripheral latency allows the peripheral to skip waking up for a certain number of connection
      * events if it doesn't have any data to send. Usually, the connection interval is a strict tradeoff
@@ -77,17 +119,44 @@ sealed class ConnectionParameters {
      * data to send, we want to have very low latency. Using the peripheral latency option, we can
      * maintain low latency but reduce power consumption by remaining idle for several connection intervals.
      *
+     * ### Supervision timeout
+     *
+     * When two devices are connected, they agree on a parameter that determines how long it should
+     * take since the last packet was successfully received until the devices consider the connection lost.
+     * This is called the supervision timeout. So if one of the devices is unexpectedly switched off,
+     * runs out of battery, or if the devices are out of radio range, then this is the amount of time
+     * it takes between successfully receiving the last packet before the connection is considered lost.
+     *
      * @param connectionInterval Connection interval in 1.25ms unit.
      *        Valid range is from 6 (7.5ms) to 3200 (4000ms).
-     * @param slaveLatency  Slave latency. Valid range is from 0 to 499.
-     * @param supervisionTimeout  Supervision timeout in 10ms unit.
+     * @param latency Connection latency. Valid range is from 0 to 499.
+     * @param supervisionTimeout Supervision timeout in 10ms unit.
      *        Valid range is from 10 (0.1s) to 3200 (32s)
      */
-    data class Connected(
+    data class Specified(
         val connectionInterval: @Range(from = 6L, to = 3200L) Int,
-        val slaveLatency: @Range(from = 0, to = 499) Int,
+        val latency: @Range(from = 0, to = 499) Int,
         val supervisionTimeout: @Range(from = 10, to = 3200) Int,
     ) : ConnectionParameters() {
+
+        /**
+         * Creates a connection parameters using [Duration] for interval and timeout.
+         *
+         * @param connectionInterval Connection interval.
+         * @param latency Connection latency.
+         * @param supervisionTimeout Supervision timeout.
+         * @see ConnectionParameters.Specified
+         */
+        constructor(
+            connectionInterval: Duration,
+            latency: Int,
+            supervisionTimeout: Duration,
+        ): this(
+            connectionInterval = (connectionInterval.inWholeMilliseconds * 100 / 125L).toInt(),
+            latency = latency,
+            supervisionTimeout = (supervisionTimeout.inWholeMilliseconds / 10L).toInt(),
+        )
+
         /**
          * Returns the connection interval in milliseconds.
          */
@@ -101,7 +170,7 @@ sealed class ConnectionParameters {
             get() = supervisionTimeout * 10L
 
         override fun toString(): String {
-            return "Interval=$connectionInterval ($connectionIntervalMillis ms), Latency=$slaveLatency, Timeout=$supervisionTimeout ($supervisionTimeoutMillis ms)"
+            return "Interval=$connectionInterval ($connectionIntervalMillis ms), Latency=$latency, Timeout=$supervisionTimeout ($supervisionTimeoutMillis ms)"
         }
     }
 }

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/util/Transform.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/util/Transform.kt
@@ -39,10 +39,20 @@ import kotlinx.coroutines.flow.flow
 /**
  * Splits the data into chunks of given length. The last chunk may be shorter.
  *
+ * ### Example
+ * ```kotlin
+ * val data = byteArrayOf(1, 2, 3, 4, 5)
+ * val chunks = data.chunked(2)
+ * // chunks: [ [1, 2], [3, 4], [5] ]
+ * ```
+ *
  * @param size The maximum size of a chunk.
  * @return A list of chunks.
  */
 fun ByteArray.chunked(size: Int): List<ByteArray> {
+    require(size > 0) { "Chunk size must be greater than 0." }
+    if (this.isEmpty()) return emptyList()
+    if (this.size <= size) return listOf(this)
     val chunks = mutableListOf<ByteArray>()
     var offset = 0
     while (offset < this.size) {
@@ -56,13 +66,36 @@ fun ByteArray.chunked(size: Int): List<ByteArray> {
 /**
  * Collects the flow of data and emits a new flow of chunked data using the given operation.
  *
+ * This operator can be used to split data into smaller chunks suitable for transmission.
+ * The implementation of the operation is application-specific. Most common use cases are:
+ * * Splitting data into fixed-size packets (`MTU - 3` bytes).
+ * * Splitting data into packets with a header with total length.
+ * * Splitting data with flag in each chunk (*single*, *first*, *middle*, or *last* packet).
+ *
+ * ### Example
+ * ```kotlin
+ * val dataFlow: Flow<ByteArray> = ...
+ * val chunkedFlow = dataFlow.chunk(20) { data, size ->
+ *    val header = data.size.toUShort().toByteArray(order = ByteOrder.BIG_ENDIAN)
+ *    val dataWithHeader = header + data
+ *    dataWithHeader.chunked(size)
+ * }
+ * ```
+ * See [Kotlin Util Library / data](https://github.com/NordicSemiconductor/Kotlin-Util-Library)
+ * for extension functions to convert numbers to byte arrays.
+ *
  * @param size The maximum size of a chunk.
  * @param operation The operation that will split the data into chunks.
  * @return A flow of chunked data.
  */
-fun Flow<ByteArray>.split(size: Int, operation: suspend (data: ByteArray, size: Int) -> List<ByteArray>): Flow<ByteArray> = flow {
-    collect { full ->
-        operation(full, size).forEach { chunk ->
+fun Flow<ByteArray>.chunk(
+    size: Int, operation: suspend (data: ByteArray, size: Int) -> List<ByteArray>
+): Flow<ByteArray> = flow {
+    collect { data ->
+        // Always apply the operation for consistent behavior.
+        // The operation is responsible for correct chunking.
+        val chunks = operation(data, size)
+        chunks.forEach { chunk ->
             emit(chunk)
         }
     }
@@ -71,10 +104,27 @@ fun Flow<ByteArray>.split(size: Int, operation: suspend (data: ByteArray, size: 
 /**
  * Collects the flow of data and emits a new flow of packet of at-most given size.
  *
+ * This operator can be used to split data into smaller chunks suitable for transmission.
+ *
+ * The data is split into chunks of given size. The last chunk may be shorter.
+ *
+ * ### Example
+ * ```kotlin
+ * val maxSize = peripheral.maximumWriteValueLength(writeType = WriteType.WITHOUT_RESPONSE)
+ * val dataFlow: Flow<ByteArray> = ...
+ * dataFlow
+ *   .chunk(maxSize)
+ *   .onEach { chunk ->
+ *       // Send the chunk to the peripheral.
+ *   }
+ *   .launchIn(scope)
+ * ```
+ *
  * @param size The maximum size of a packet.
  * @return A flow of packets.
  */
-fun Flow<ByteArray>.split(size: Int): Flow<ByteArray> = split(size) { data, _ -> data.chunked(size) }
+fun Flow<ByteArray>.chunk(size: Int): Flow<ByteArray> =
+    chunk(size) { data, _ -> data.chunked(size) }
 
 /**
  * Collects the flow of packets and emits a new flow of merged data using the given operation.
@@ -96,17 +146,18 @@ fun Flow<ByteArray>.split(size: Int): Flow<ByteArray> = split(size) { data, _ ->
  * @param operation The operation that will merge the data.
  * @return A flow of merged data.
  */
-fun Flow<ByteArray>.merge(operation: suspend (accumulator: ByteArray, received: ByteArray) -> MergeResult): Flow<ByteArray> = flow {
+fun Flow<ByteArray>.merge(
+    operation: suspend (accumulator: ByteArray, received: ByteArray) -> MergeResult
+): Flow<ByteArray> = flow {
     var accumulator = byteArrayOf()
     collect { received ->
-        accumulator = when (val result = operation(accumulator, received)) {
+        when (val result = operation(accumulator, received)) {
             is MergeResult.Accumulate -> {
-                result.accumulated
+                accumulator = result.accumulated
             }
-
             is MergeResult.Completed -> {
+                accumulator = byteArrayOf()
                 emit(result.result)
-                byteArrayOf()
             }
         }
     }
@@ -132,19 +183,20 @@ fun Flow<ByteArray>.merge(operation: suspend (accumulator: ByteArray, received: 
  * @param operation The operation that will merge the data.
  * @return A flow of merged data.
  */
-fun Flow<ByteArray>.mergeIndexed(operation: suspend (accumulator: ByteArray, received: ByteArray, index: Int) -> MergeResult): Flow<ByteArray> = flow {
+fun Flow<ByteArray>.mergeIndexed(
+    operation: suspend (accumulator: ByteArray, received: ByteArray, index: Int) -> MergeResult
+): Flow<ByteArray> = flow {
     var accumulator = byteArrayOf()
     var index = 0
     collect { received ->
-        accumulator = when (val result = operation(accumulator, received, index++)) {
+        when (val result = operation(accumulator, received, index++)) {
             is MergeResult.Accumulate -> {
-                result.accumulated
+                accumulator = result.accumulated
             }
-
             is MergeResult.Completed -> {
-                emit(result.result)
                 index = 0
-                byteArrayOf()
+                accumulator = byteArrayOf()
+                emit(result.result)
             }
         }
     }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -172,9 +172,9 @@ class ScannerViewModel @Inject constructor(
                 .apply {
                     launch {
                         try {
-                            withTimeout(5000) {
-                                connect(peripheral, false)
-                            }
+                            // This could be wrapped in withTimeout, but the Direct option
+                            // already specifies a timeout.
+                            connect(peripheral, false)
 
                             // The first time the app connects to the peripheral it needs to initiate
                             // observers for various parameters.

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
@@ -311,15 +310,26 @@ class ScannerViewModel @Inject constructor(
 
     @OptIn(ExperimentalUuidApi::class)
     private fun observerServices(peripheral: Peripheral, scope: CoroutineScope) {
+        // Services will change multiple times. Initially, the services() will emit null (event 1).
+        // When services are discovered, it will emit the list of services (event 2).
+        // If the services change later, it will emit null again (event 3) and the new list (event 4).
+        // The event index is printed to be able to track which services does this apply to.
+        var event = 0
+
         peripheral.services()
             .onEach { services ->
-                Timber.i("Services changed: $services")
+                // On each services change, increment the event index.
+                event += 1
+                Timber.i("($event) Services changed: $services")
             }
             .filterNotNull()
             .onEach { services ->
+                // Keep the current event fixed in this block.
+                val ce = event
+
                 // Read values of all characteristics.
                 services.forEach { remoteService ->
-                    Timber.i("Reading characteristics of ${remoteService.uuid}:")
+                    Timber.i("($ce) Reading characteristics of ${remoteService.uuid}:")
                     remoteService.characteristics.forEach { remoteCharacteristic ->
                         try {
                             val value = remoteCharacteristic.read()
@@ -341,28 +351,40 @@ class ScannerViewModel @Inject constructor(
 
                 services.forEach { remoteService ->
                     remoteService.characteristics.forEach { remoteCharacteristic ->
-                        Timber.w("Subscribing to ${remoteCharacteristic.uuid}...")
+                        // subscribe() will throw OperationFailedException with reason
+                        // SUBSCRIPTION_NOT_SUPPORTED if the characteristic doesn't support
+                        // notifications or indications.
+                        val expectError = !remoteCharacteristic.isSubscribable()
                         try {
-                            // subscribe() will throw OperationFailedException with reason
-                            // SUBSCRIPTION_NOT_SUPPORTED if the characteristic doesn't support
-                            // notifications or indications.
                             remoteCharacteristic.subscribe()
+                                .onStart {
+                                    // This is called before the notifications are enabled.
+                                    Timber.w("($ce) Subscribing to ${remoteCharacteristic.uuid}...")
+                                }
                                 .onEach { newValue ->
-                                    Timber.i("Value of ${remoteCharacteristic.uuid} changed: 0x${newValue.toHexString()}")
+                                    // This is called when a notification or indication is received.
+                                    Timber.i("($ce) Value of ${remoteCharacteristic.uuid} changed: 0x${newValue.toHexString()}")
                                 }
                                 .catch { e ->
-                                    Timber.e("Subscription to ${remoteCharacteristic.uuid} failed: ${e.message}")
+                                    // This is called when subscription fails.
+                                    Timber.e("($ce) Subscription to ${remoteCharacteristic.uuid} failed: ${e.message}")
                                 }
                                 .onEmpty {
-                                    Timber.w("No updates from ${remoteCharacteristic.uuid}")
+                                    // This is called when the characteristic sent no notifications.
+                                    Timber.w("($ce) No updates from ${remoteCharacteristic.uuid}")
                                 }
                                 .onCompletion {
-                                    Timber.d("Stopped observing updates from ${remoteCharacteristic.uuid}")
+                                    // This is called when the characteristic becomes invalid,
+                                    // that is on disconnection or service change.
+                                    Timber.d("($ce) Stopped observing updates from ${remoteCharacteristic.uuid}")
                                 }
                                 .launchIn(scope)
-                            Timber.i("Notifications for ${remoteCharacteristic.uuid} are now ${if (remoteCharacteristic.isNotifying) "enabled" else "disabled"}")
+                            // remoteCharacteristic.setNotifying(true)
+                            Timber.i("($ce) Notifications for ${remoteCharacteristic.uuid} are now ${if (remoteCharacteristic.isNotifying) "enabled" else "disabled"}")
                         } catch (e: Exception) {
-                            Timber.e("Failed to subscribe to ${remoteCharacteristic.uuid}: ${e.message}")
+                            if (!expectError) {
+                                Timber.e("($ce) Failed to subscribe to ${remoteCharacteristic.uuid}: ${e.message}")
+                            }
                         }
                     }
                 }
@@ -372,19 +394,30 @@ class ScannerViewModel @Inject constructor(
                 val blinkyServiceUuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
                 val blinkyService = services.firstOrNull { it.uuid == blinkyServiceUuid }
                 blinkyService?.let { service ->
+                    val buttonCharacteristicUuid = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
                     val ledCharacteristicUuid = Uuid.parse("00001525-1212-efde-1523-785feabcd123")
+                    val buttonCharacteristic = service.characteristics.firstOrNull { it.uuid == buttonCharacteristicUuid }
                     val ledCharacteristic = service.characteristics.firstOrNull { it.uuid == ledCharacteristicUuid }
+
+                    Timber.i("($ce) Awaiting for button press to start LED blinking...")
+                    val result = buttonCharacteristic?.waitForValueChange {
+                        Timber.i("($ce) Turning LED on...")
+                        ledCharacteristic?.write(byteArrayOf(0x01))
+                    }
+                    Timber.i("($ce) Button change to 0x${result?.toHexString()}")
+
                     ledCharacteristic?.let { led ->
-                        Timber.i("Starting to blink LED...")
+                        Timber.i("($ce) Starting to blink LED...")
                         scope.launch {
                             try {
                                 repeat(10) { i ->
-                                    val newValue = byteArrayOf(((i + 1) % 2).toByte())
+                                    val newValue = byteArrayOf((i % 2).toByte())
+                                    Timber.i("($ce) Writing 0x${newValue.toHexString()} to ${led.uuid}...")
                                     led.write(newValue)
                                     delay(250.milliseconds)
                                 }
                             } catch (e: Exception) {
-                                Timber.e("Failed to write to ${led.uuid}: ${e.message}")
+                                Timber.e("($ce) Failed to write to ${led.uuid}: ${e.message}")
                             }
                         }
                     }

--- a/sample/src/mock/java/no/nordicsemi/kotlin/ble/android/sample/di/ViewModelModule.kt
+++ b/sample/src/mock/java/no/nordicsemi/kotlin/ble/android/sample/di/ViewModelModule.kt
@@ -50,6 +50,7 @@ import no.nordicsemi.kotlin.ble.client.mock.PeripheralSpec
 import no.nordicsemi.kotlin.ble.client.mock.PeripheralSpecEventHandler
 import no.nordicsemi.kotlin.ble.client.mock.Proximity
 import no.nordicsemi.kotlin.ble.client.mock.ReadResponse
+import no.nordicsemi.kotlin.ble.client.mock.ServiceDiscoveryResult
 import no.nordicsemi.kotlin.ble.client.mock.WriteResponse
 import no.nordicsemi.kotlin.ble.client.mock.internal.MockRemoteCharacteristic
 import no.nordicsemi.kotlin.ble.core.AdvertisingDataFlag
@@ -102,10 +103,16 @@ object ViewModelModule {
         private var isButtonPressed = false
             set(value) {
                 buttonHandle?.let {
-                    Timber.i("[Blinky]: Simulating Button ${if (value) "clicked" else "released"}")
+                    Timber.i("[Blinky] Simulating Button ${if (value) "clicked" else "released"}")
                     blinky.simulateValueUpdate(it, value.toBytes())
                 }
             }
+        /**
+         * Counts how many times the LED characteristic was written to.
+         *
+         * Used to simulate a service change after 5 writes with response.
+         */
+        private var blinkCount = 0
 
         // Event handlers implementation
 
@@ -115,22 +122,65 @@ object ViewModelModule {
         }
 
         override fun onConnectionLost(reason: DisconnectionReason) {
-            Timber.i("[Blinky] Connection terminated")
-            super.onConnectionLost(reason)
+            Timber.i("[Blinky] Connection terminated: $reason")
+        }
+
+        override fun onReset() {
+            Timber.i("[Blinky] --- Booting up ---")
+            blinkCount = 0
+            isLedOn = false
+            isButtonPressed = false
+        }
+
+        override fun onServiceDiscoveryRequest(uuids: List<Uuid>): ServiceDiscoveryResult {
+            Timber.i("[Blinky] Service discovery requested for UUIDs: $uuids")
+            return super.onServiceDiscoveryRequest(uuids)
         }
 
         override fun onWriteRequest(
             characteristic: MockRemoteCharacteristic,
             value: ByteArray
         ): WriteResponse {
-            val on = value.isOn()
-            isLedOn = on
-            Timber.i("[Blinky]: LED ${if (on) "ON" else "OFF"}")
+            onWriteCommand(characteristic, value)
+
+            // After 5 writes with response, simulate a service change.
+            // Note, that the counter isn't reset, so the change happens only once.
+            if (blinkCount++ == 5) {
+                Timber.i("[Blinky] Changing services")
+                blinky.simulateServiceChange {
+                    GenericAccessService()
+                    GenericAttributeService()
+                    // Add LED Button Service (Blinky)
+                    Service(
+                        uuid = Uuid.parse("00001523-1212-EFDE-1523-785FEABCD123")
+                    ) {
+                        buttonHandle = Characteristic(
+                            uuid = Uuid.parse("00001524-1212-EFDE-1523-785FEABCD123"),
+                            properties = CharacteristicProperty.READ and CharacteristicProperty.NOTIFY,
+                            permission = Permission.READ,
+                        )
+                        ledHandle = Characteristic(
+                            uuid = Uuid.parse("00001525-1212-EFDE-1523-785FEABCD123"),
+                            properties = CharacteristicProperty.READ and CharacteristicProperty.WRITE_WITHOUT_RESPONSE,
+                            permissions = Permission.READ and Permission.WRITE,
+                        ) {
+                            // CCCD is added automatically
+                            CharacteristicUserDescriptionDescriptor("LED 2")
+                        }
+                    }
+                }
+            }
 
             // Send a Button notification when LED characteristic is written to.
-            isButtonPressed = on
+            isButtonPressed = value.isOn()
 
             return WriteResponse.Success
+        }
+
+        override fun onWriteCommand(characteristic: MockRemoteCharacteristic, value: ByteArray) {
+            val on = value.isOn()
+            isLedOn = on
+            Timber.i("[Blinky] LED ${if (on) "ON" else "OFF"}")
         }
 
         override fun onReadRequest(characteristic: MockRemoteCharacteristic): ReadResponse =
@@ -139,7 +189,6 @@ object ViewModelModule {
                 ledHandle -> ReadResponse.Success(isLedOn.toBytes())
                 else -> ReadResponse.Failure(OperationStatus.READ_NOT_PERMITTED)
             }
-
     }
 
     /** Definition of the Blinky device. */
@@ -213,7 +262,8 @@ object ViewModelModule {
                             writableAuxiliaries = true
                         )
                         // A custom descriptor with write-only property. Just for fun.
-                        Descriptor(Uuid.random(), permission = Permission.WRITE)
+                        // TODO Reading this should trigger bonding
+                        Descriptor(Uuid.random(), permission = Permission.READ_ENCRYPTED)
                     }
                     ledHandle = Characteristic(
                         uuid = Uuid.parse("00001525-1212-EFDE-1523-785FEABCD123"),
@@ -240,11 +290,27 @@ object ViewModelModule {
         return BluetoothLeAdvertiser.Factory.mock(environment)
     }
 
+    private val beacon = PeripheralSpec.simulatePeripheral(
+        identifier = "11:22:33:44:55:66",
+        proximity = Proximity.NEAR
+    ) {
+        advertising(
+            parameters = LegacyAdvertisingSetParameters(
+                connectable = false,
+                interval = 1.seconds,
+            ),
+        ) {
+            CompleteLocalName("Nordic_Beacon")
+            ServiceUuid(Uuid.fromShortUuid(0xFEAA)) // Eddystone UUID
+            IncludeTxPowerLevel()
+        }
+    }
+
     @Provides
     fun provideCentralManager(scope: CoroutineScope, environment: MockEnvironment): CentralManager {
         return CentralManager.Factory.mock(scope, environment)
             .apply {
-                simulatePeripherals(listOf(blinky))
+                simulatePeripherals(listOf(blinky, beacon))
             }
     }
 

--- a/sample/src/mock/java/no/nordicsemi/kotlin/ble/android/sample/di/ViewModelModule.kt
+++ b/sample/src/mock/java/no/nordicsemi/kotlin/ble/android/sample/di/ViewModelModule.kt
@@ -37,7 +37,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.ViewModelLifecycle
 import dagger.hilt.android.components.ViewModelComponent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import no.nordicsemi.kotlin.ble.advertiser.android.BluetoothLeAdvertiser
 import no.nordicsemi.kotlin.ble.advertiser.android.mock.mock
 import no.nordicsemi.kotlin.ble.android.mock.MockEnvironment
@@ -56,6 +59,7 @@ import no.nordicsemi.kotlin.ble.client.mock.internal.MockRemoteCharacteristic
 import no.nordicsemi.kotlin.ble.core.AdvertisingDataFlag
 import no.nordicsemi.kotlin.ble.core.Bluetooth5AdvertisingSetParameters
 import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
+import no.nordicsemi.kotlin.ble.core.ConnectionParameters
 import no.nordicsemi.kotlin.ble.core.LegacyAdvertisingSetParameters
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.Permission
@@ -168,6 +172,19 @@ object ViewModelModule {
                             CharacteristicUserDescriptionDescriptor("LED 2")
                         }
                     }
+                }
+                CoroutineScope(Dispatchers.IO).launch {
+                    // Request shorter supervision timeout.
+                    delay(5000)
+                    blinky.simulateConnectionParametersRequest(ConnectionParameters(
+                        connectionInterval = 30.milliseconds,
+                        latency = 4,
+                        supervisionTimeout = 1.seconds,
+                    ))
+                    // Simulate a reset after a while. The Peripheral should get disconnection
+                    // event after 1 second (supervision timeout).
+                    delay(2000)
+                    blinky.simulateReset()
                 }
             }
 


### PR DESCRIPTION
This PR adds the following changes:
1. A standard 30 sec timeout for a "direct" connection on Android will now be reported as `TimeoutCancellationException`, just like one set using `timeout` parameter.
2. [Breaking] `subscribe()` is no longer a suspend method. The `setNotifying(true)` is called in `onSubscription`, so in collector's scope.
3. [Breaking] `waitForValueChange` API changed - now takes also `rawDataFolter`, `merge` and `filter` parameters (optional) to allow processing received packets before returning the final version. 
4. [Breaking] `ConnectionParameters.Connected` was renamed to `ConnectionParameters.Specified`. This works better with `Unknown`, which also means that the peripheral is connected. Previous name was missleading.
5. Bugs fixed.