### PR TITLE
Migration to AGP 9.0.0

### DIFF
--- a/advertiser-android-mock/build.gradle.kts
+++ b/advertiser-android-mock/build.gradle.kts
@@ -54,11 +54,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.advertiser.android.mock.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/advertiser-android/build.gradle.kts
+++ b/advertiser-android/build.gradle.kts
@@ -63,11 +63,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.advertiser.android.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/advertiser-core-android/build.gradle.kts
+++ b/advertiser-core-android/build.gradle.kts
@@ -52,11 +52,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.advertiser.android.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/advertiser-core-android/src/main/java/no/nordicsemi/kotlin/ble/advertiser/android/BluetoothLeAdvertiser.kt
+++ b/advertiser-core-android/src/main/java/no/nordicsemi/kotlin/ble/advertiser/android/BluetoothLeAdvertiser.kt
@@ -81,7 +81,7 @@ abstract class BluetoothLeAdvertiser(
      * @param parameters Advertising parameters describing how the data are to be advertised.
      * @param payload Advertising data to be broadcast.
      * @param timeout The advertising time limit. May not exceed 180.000 ms on Android 5-7 and
-     * 655.350 ms on Android 8+. By default there is no timeout set.
+     * 655.350 ms on Android 8+. By default, there is no timeout set.
      * @param block A block that will be called when the advertising is started. The block will
      * receive the actual TX power (in dBm) used for advertising.
      * @throws SecurityException If the BLUETOOTH_ADVERTISE permission is denied.

--- a/advertiser-core/build.gradle.kts
+++ b/advertiser-core/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
     }
 }

--- a/advertiser-core/src/main/java/no/nordicsemi/kotlin/ble/advertiser/BluetoothLeAdvertiser.kt
+++ b/advertiser-core/src/main/java/no/nordicsemi/kotlin/ble/advertiser/BluetoothLeAdvertiser.kt
@@ -50,7 +50,7 @@ interface BluetoothLeAdvertiser<
      *
      * @param connectable Whether the advertising should be connectable.
      * @param payload Advertising data to be broadcast.
-     * @param timeout The advertising time limit. By default there is no timeout set.
+     * @param timeout The advertising time limit. By default, there is no timeout set.
      * @param block A block that will be called when the advertising is started. The block will
      * receive the actual TX power (in dBm) used for advertising.
      * @throws SecurityException If the required permission is denied.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp) apply false
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,12 +41,6 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp) apply false
 
-    // This plugin is used to generate Dokka documentation.
-    alias(libs.plugins.kotlin.dokka) apply false
-    // This applies Nordic look & feel to generated Dokka documentation.
-    // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/NordicDokkaPlugin.kt
-    alias(libs.plugins.nordic.dokka) apply true
-
     // Nordic plugins are defined in https://github.com/NordicSemiconductor/Android-Gradle-Plugins
     alias(libs.plugins.nordic.application) apply false
     alias(libs.plugins.nordic.application.compose) apply false
@@ -58,6 +52,12 @@ plugins {
     alias(libs.plugins.nordic.feature) apply false
     alias(libs.plugins.nordic.nexus.android) apply false
     alias(libs.plugins.nordic.nexus.jvm) apply false
+
+    // This plugin is used to generate Dokka documentation.
+    alias(libs.plugins.kotlin.dokka) apply false
+    // This applies Nordic look & feel to generated Dokka documentation.
+    // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/NordicDokkaPlugin.kt
+    alias(libs.plugins.nordic.dokka) apply true
 }
 
 // Configure main Dokka page

--- a/client-android-mock/build.gradle.kts
+++ b/client-android-mock/build.gradle.kts
@@ -55,11 +55,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.client.android.mock.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/client-android/build.gradle.kts
+++ b/client-android/build.gradle.kts
@@ -62,11 +62,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.client.android.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/client-core-android/build.gradle.kts
+++ b/client-core-android/build.gradle.kts
@@ -57,11 +57,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.client.android.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -495,7 +495,7 @@ open class Peripheral(
      * Controller can override these settings.
      *
      * @param txPhy The preferred transmitter PHY.
-     * @param rxPhy The preferred receiver PHY. By default it is the same as [txPhy].
+     * @param rxPhy The preferred receiver PHY. By default, it is the same as [txPhy].
      * @param phyOptions The preferred coding to use when transmitting on the LE Coded PHY.
      * @return The PHYs in use after the change.
      * @throws PeripheralNotConnectedException If the device is not connected.

--- a/client-core/build.gradle.kts
+++ b/client-core/build.gradle.kts
@@ -58,11 +58,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.client.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
@@ -143,7 +143,7 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * }
      * ```
      * @param data The data to be written.
-     * @param writeType The write type to be used. By default set to the characteristic's
+     * @param writeType The write type to be used. By default, it is set to the characteristic's
      * default write type based on its properties.
      * @throws ValueDoesNotMatchException if the value was sent using *Long Write* or *Reliable Write*
      * procedure and the value replied back by the peripheral does not match the value written.

--- a/client-mock/build.gradle.kts
+++ b/client-mock/build.gradle.kts
@@ -55,11 +55,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.client.mock.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/client-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -1085,7 +1085,7 @@ class PeripheralSpec<ID: Any> private constructor(
          *
          * @param parameters The advertising parameters.
          * @param delay The delay before the advertising starts.
-         * @param timeout The advertising timeout, since the start of advertising. By default set to infinite.
+         * @param timeout The advertising timeout, since the start of advertising. By default, set to infinite.
          * @param isAdvertisingWhenConnected Whether the device should advertise when connected.
          * @param isBeacon Whether the device is a beacon which can reveal user's location, that is
          * an iBeacon or Eddystone beacon. On Android 12+ such advertisements require location

--- a/core-android/build.gradle.kts
+++ b/core-android/build.gradle.kts
@@ -51,11 +51,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.core.android.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/core-mock/build.gradle.kts
+++ b/core-mock/build.gradle.kts
@@ -51,11 +51,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.core.mock.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -51,11 +51,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.core.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/environment-android-compose/build.gradle.kts
+++ b/environment-android-compose/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
     }
 }

--- a/environment-android-compose/src/main/java/no/nordicsemi/kotlin/ble/environment/android/compose/LocalEnvironment.kt
+++ b/environment-android-compose/src/main/java/no/nordicsemi/kotlin/ble/environment/android/compose/LocalEnvironment.kt
@@ -86,7 +86,7 @@ object LocalEnvironmentOwner {
         get() = LocalEnvironment.current?: run {
             val context = LocalContext.current
             return try {
-                NativeAndroidEnvironment.getInstance(context,Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+                NativeAndroidEnvironment.getInstance(context, isNeverForLocationFlagSet = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
             } catch (e: NoClassDefFoundError) {
                 try {
                     LatestApi()

--- a/environment-android-mock/build.gradle.kts
+++ b/environment-android-mock/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
     }
 }

--- a/environment-android-mock/src/main/java/no/nordicsemi/kotlin/ble/environment/android/mock/MockAndroidEnvironment.kt
+++ b/environment-android-mock/src/main/java/no/nordicsemi/kotlin/ble/environment/android/mock/MockAndroidEnvironment.kt
@@ -29,6 +29,8 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("unused")
+
 package no.nordicsemi.kotlin.ble.environment.android.mock
 
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,14 +46,24 @@ import org.jetbrains.annotations.Range
 import org.slf4j.LoggerFactory
 
 /**
- * The environment for the latest Android API.
+ * A type alias for the lastest Android API.
+ *
+ * Currently, this is set to [MockAndroidEnvironment.Api31] and will change in the future to match
+ * the latest Android API, when available.
+ *
+ * Note, that ApiXX is also valid for APIs greater than XX. A new type is only added when there's
+ * a significant change in the Bluetooth-related API.
  */
 typealias LatestApi = MockAndroidEnvironment.Api31
+
 /**
- * A type for a mock advertiser.
+ * A callback used for a mock advertiser.
  *
  * This callback is called when the app requests the mock Bluetooth LE advertiser to advertise.
- * It should return the TX power level used for mock advertising, in dBm.
+ *
+ * It should return an emulated value of TX power level used for mock advertising, in dBm, which
+ * will be delivered the callback block given in `BluetoothLeAdvertiser.advertise(...)` method.
+ *
  * Valid values are from -127 to +1 dBm.
  */
 typealias MockAdvertiser = (requestedTxPower: Int, advertisingData: AdvertisingDataDefinition, scanResponse: AdvertisingDataDefinition?) -> Result<Int>
@@ -62,7 +74,7 @@ private val DEFAULT_MOCK_ADVERTISER: MockAdvertiser = { requestedTxPower, _, _ -
 }
 
 /**
- * A type for a mock scanner.
+ * A callback used for a mock scanner.
  *
  * This callback is called when the mock central manager requests a scan for Bluetooth LE devices.
  *
@@ -403,7 +415,7 @@ sealed class MockAndroidEnvironment(
      *
      * See:
      * * [Bluetooth Permissions](https://developer.android.com/develop/connectivity/bluetooth/bt-permissions)
-     * * [`neverForLocation flag`](https://developer.android.com/develop/connectivity/bluetooth/bt-permissions#assert-never-for-location)
+     * * [`neverForLocation` flag](https://developer.android.com/develop/connectivity/bluetooth/bt-permissions#assert-never-for-location)
      *
      * @param deviceName The device name, by default set to "Mock".
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
@@ -486,6 +498,20 @@ sealed class MockAndroidEnvironment(
         issueIncorrectL2capTxMtu = issueIncorrectL2capTxMtu,
     )
 
+    /**
+     * A mock environment for the Nexus 4.
+     *
+     * This device may only use active scanning once per scan session for a given device. That means,
+     * that Scan Request is only sent once per discovered connectable device, resulting in only a
+     * single scan record received from such devices.
+     *
+     * @param deviceName The device name, by default set to "Nexus 4".
+     * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
+     * @param advertiser A callback that will be called when the app requests to advertise.
+     * The callback should return TX power level used for mock advertising.
+     * @param scanner A callback that will be called when the mock central manager requests to scan
+     * for devices. It returns whether the scan was successful, secretly failed, or returned an error.
+     */
     class Nexus4(
         deviceName: String = "Nexus 4",
         isBluetoothEnabled: Boolean = true,
@@ -502,6 +528,30 @@ sealed class MockAndroidEnvironment(
         issueOnlyOneActiveScan = true,
     )
 
+    /**
+     * A mock environment for the Samsung A8 with Android 14.
+     *
+     * That device fails to properly negotiate the Maximum Transfer Usage (MTU) and Data Length
+     * Extension (DLE). It incorrectly claims, that can only transfer 27 bytes in a single LL packet,
+     * while later trying to send 251 bytes.
+     *
+     * This causes the peer device to terminate the connection. A workaround for that is not requesting
+     * MTU higher than 23 (maximum value length equal to 20 bytes).
+     *
+     * @param deviceName The device name, by default set to "Samsung A8".
+     * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
+     * @param isBluetoothScanPermissionGranted Whether the `BLUETOOTH_SCAN` permission is granted.
+     * @param isBluetoothConnectPermissionGranted Whether the `BLUETOOTH_CONNECT` permission is granted.
+     * @param isBluetoothAdvertisePermissionGranted Whether the `BLUETOOTH_ADVERTISE` permission is granted.
+     * @param isNeverForLocationFlagSet Whether the app is not using results of Bluetooth LE scanning
+     * to estimate device location. By default, `neverForLocation` flag is assumed.
+     * @param isLocationPermissionGranted Whether the fine location permission is initially granted.
+     * @param isLocationEnabled Whether location service is enabled on the device.
+     * @param advertiser A callback that will be called when the app requests to advertise.
+     * The callback should return TX power level used for mock advertising.
+     * @param scanner A callback that will be called when the mock central manager requests to scan
+     * for devices. It returns whether the scan was successful, secretly failed, or returned an error.
+     */
     class SamsungA8(
         deviceName: String = "Samsung A8",
         isBluetoothEnabled: Boolean = true,

--- a/environment-android/build.gradle.kts
+++ b/environment-android/build.gradle.kts
@@ -28,11 +28,7 @@ dependencies {
 }
 
 dokka {
-    dokkaSourceSets.named("main") {
+    dokkaSourceSets.configureEach {
         includes.from("Module.md")
-        perPackageOption {
-            matchingRegex.set("no.nordicsemi.kotlin.ble.environment.android.internal")
-            suppress.set(true)
-        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,6 +52,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.proguard.failOnMissingFiles=false
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Thu Jul 03 17:34:01 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -24,10 +24,14 @@ android {
 }
 
 dependencies {
-    implementation(project(":advertiser-android"))
-    implementation(project(":advertiser-android-mock"))
-    implementation(project(":client-android"))
-    implementation(project(":client-android-mock"))
+    // Add dependencies to native implementations in "native" flavor.
+    "nativeImplementation"(project(":advertiser-android"))
+    "nativeImplementation"(project(":client-android"))
+    // For "mock" flavor, use the mock implementations.
+    "mockImplementation"(project(":advertiser-android-mock"))
+    "mockImplementation"(project(":client-android-mock"))
+    // For debug, let's use mock (for Previews).
+    "debugImplementation"(project(":environment-android-mock"))
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserView.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserView.kt
@@ -50,12 +50,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import no.nordicsemi.kotlin.ble.android.sample.view.ExposedDropdownMenu
 import no.nordicsemi.kotlin.ble.android.sample.view.LabeledSwitch
@@ -68,7 +68,6 @@ import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PrimaryPhy
 import no.nordicsemi.kotlin.ble.core.TxPowerLevel
 import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
-import no.nordicsemi.kotlin.ble.environment.android.mock.MockAndroidEnvironment
 import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
@@ -90,7 +89,7 @@ fun AdvertiserView(
         var txPowerLevelMenuExpanded by rememberSaveable { mutableStateOf(false) }
         var txPowerLevel by rememberSaveable { mutableIntStateOf(TxPowerLevel.MEDIUM) }
         var intervalMenuExpanded by rememberSaveable { mutableStateOf(false) }
-        var interval by rememberSaveable { mutableStateOf(AdvertisingInterval.MEDIUM.inWholeMilliseconds) }
+        var interval by rememberSaveable { mutableLongStateOf(AdvertisingInterval.MEDIUM.inWholeMilliseconds) }
         var anonymous by rememberSaveable { mutableStateOf(false) }
         var scannable by rememberSaveable { mutableStateOf(false) }
         var discoverable by rememberSaveable { mutableStateOf(false) }
@@ -314,14 +313,14 @@ fun AdvertiserView(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-private fun PreviewAdvertiserScreen() {
-    AdvertiserView(
-        isAdvertising = false,
-        onStartClicked = { },
-        onStopClicked = { },
-        errorMessage = "Error!",
-        environment = MockAndroidEnvironment.Api31()
-    )
-}
+//@Preview(showBackground = true)
+//@Composable
+//private fun PreviewAdvertiserScreen() {
+//    AdvertiserView(
+//        isAdvertising = false,
+//        onStartClicked = { },
+//        onStopClicked = { },
+//        errorMessage = "Error!",
+//        environment = MockAndroidEnvironment.Api31()
+//    )
+//}

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserView.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserView.kt
@@ -56,6 +56,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import no.nordicsemi.kotlin.ble.android.sample.view.ExposedDropdownMenu
 import no.nordicsemi.kotlin.ble.android.sample.view.LabeledSwitch
@@ -68,6 +69,7 @@ import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PrimaryPhy
 import no.nordicsemi.kotlin.ble.core.TxPowerLevel
 import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
+import no.nordicsemi.kotlin.ble.environment.android.mock.MockAndroidEnvironment
 import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
@@ -313,14 +315,14 @@ fun AdvertiserView(
     }
 }
 
-//@Preview(showBackground = true)
-//@Composable
-//private fun PreviewAdvertiserScreen() {
-//    AdvertiserView(
-//        isAdvertising = false,
-//        onStartClicked = { },
-//        onStopClicked = { },
-//        errorMessage = "Error!",
-//        environment = MockAndroidEnvironment.Api31()
-//    )
-//}
+@Preview(showBackground = true)
+@Composable
+private fun PreviewAdvertiserScreen() {
+    AdvertiserView(
+        isAdvertising = false,
+        onStartClicked = { },
+        onStopClicked = { },
+        errorMessage = "Error!",
+        environment = MockAndroidEnvironment.Api31()
+    )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,7 +68,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         // Use Nordic Gradle Version Catalog with common external libraries versions.
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.11.1")
+            from("no.nordicsemi.android.gradle:version-catalog:2.11.3")
         }
         // Fixed versions for Nordic libraries.
         create("nordic") {


### PR DESCRIPTION
This PR migrates the library to Nordic Android Gradle Plugins [2.11.3](https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/2.11.3):
* AGP 9.0
* Kotlin 2.3.10
* Dokka 2.2.0-Beta