### PR TITLE
Permissios improvements

### DIFF
--- a/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockCentralManagerImpl.kt
+++ b/client-android-mock/src/main/java/no/nordicsemi/kotlin/ble/client/android/mock/internal/MockCentralManagerImpl.kt
@@ -157,7 +157,7 @@ open class MockCentralManagerImpl(
         // - known peripherals with bond information
         // - peripherals that have not been scanned yet, but are bonded (PeripheralSpec.isBonded == true)
         // Should we just iterate over peripheral specs, we would miss those that were bonded
-        // in in runtime and would make all specs "known" (available for retrieval).
+        // in runtime and would make all specs "known" (available for retrieval).
         // Should we iterate only managed, we would miss devices that were defined as bonded,
         // but were not scanned yet.
         val managedBondedPeripherals = managedPeripherals.values

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
@@ -101,8 +101,9 @@ internal fun Int.errorCodeToReason(): ScanningFailedToStartException.Reason = wh
 internal fun NativeScanResult.toScanResult(peripheral: (device: BluetoothDevice, name: String?) -> Peripheral): ScanResult? {
     val scanRecord = scanRecord ?: return null
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val deviceName = try { device.name } catch (_: SecurityException) { null }
         ScanResult(
-            peripheral = peripheral(device, scanRecord.deviceName ?: device.name),
+            peripheral = peripheral(device, scanRecord.deviceName ?: deviceName),
             isConnectable =  isConnectable,
             advertisingData = scanRecord.toAdvertisementData(),
             rssi = rssi,

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -109,7 +109,11 @@ open class Peripheral(
         /** The Bluetooth device type of the remote device. */
         val type: PeripheralType
 
-        /** Bonding state as a state flow. */
+        /**
+         * Bonding state as a state flow.
+         *
+         * @throws SecurityException If BLUETOOTH_CONNECT permission is denied.
+         */
         val bondState: StateFlow<BondState>
 
         /**
@@ -875,7 +879,7 @@ open class Peripheral(
      *
      * #### Security Note
      * State [BondState.BONDED] does not guarantee that the connection to the device is secure.
-     * Some Android devices allow connecting to bonded devices without restoring encryption
+     * Some Android devices allow connecting to bonded devices without restoring encryption,
      * or they remove the bond information when it fails.
      */
     val bondState: StateFlow<BondState>

--- a/core-android/src/main/java/no/nordicsemi/kotlin/ble/core/android/AndroidEnvironment.kt
+++ b/core-android/src/main/java/no/nordicsemi/kotlin/ble/core/android/AndroidEnvironment.kt
@@ -29,6 +29,8 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("unused")
+
 package no.nordicsemi.kotlin.ble.core.android
 
 import kotlinx.coroutines.flow.StateFlow
@@ -63,21 +65,34 @@ import org.jetbrains.annotations.Range
  */
 interface AndroidEnvironment : Environment {
     /**
+     * Android permissions.
+     *
+     * The constants are useful to request permissions on devices running older Android version,
+     * i.e. using mock implementation.
+     */
+    object Permission {
+        /** Bluetooth Connect permission. */
+        const val BLUETOOTH_CONNECT = "android.permission.BLUETOOTH_CONNECT"
+        /** Bluetooth Scan permission. */
+        const val BLUETOOTH_SCAN = "android.permission.BLUETOOTH_SCAN"
+        /** Bluetooth Advertise permission. */
+        const val BLUETOOTH_ADVERTISE = "android.permission.BLUETOOTH_ADVERTISE"
+    }
+
+    /**
      * Android SDK versions.
      */
-    class SdkVersion {
-        companion object {
-            /** Android 5.0 */
-            const val LOLLIPOP = 21
-            /** Android 6.0 */
-            const val MARSHMALLOW = 23
-            /** Android 8.0 */
-            const val OREO = 26
-            /** Android 12 */
-            const val S = 31
-            /** Android 15 */
-            const val VANILLA_ICE_CREAM = 35
-        }
+    object SdkVersion {
+        /** Android 5.0 */
+        const val LOLLIPOP = 21
+        /** Android 6.0 */
+        const val MARSHMALLOW = 23
+        /** Android 8.0 */
+        const val OREO = 26
+        /** Android 12 */
+        const val S = 31
+        /** Android 15 */
+        const val VANILLA_ICE_CREAM = 35
     }
 
     val bluetoothState: StateFlow<Manager.State>

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -63,6 +63,8 @@ dependencies {
     "mockImplementation"(project(":client-android-mock"))
     // For debug, let's use mock (for Previews).
     "debugImplementation"(project(":environment-android-mock"))
+    // This is to provide the Environment for Composables.
+    implementation(project(":environment-android-compose"))
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/MainActivity.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
@@ -29,6 +30,7 @@ import no.nordicsemi.kotlin.ble.android.sample.menu.MenuScreen
 import no.nordicsemi.kotlin.ble.android.sample.scanner.ScannerScreen
 import no.nordicsemi.kotlin.ble.android.sample.theme.AppTheme
 import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
+import no.nordicsemi.kotlin.ble.environment.android.compose.LocalEnvironmentOwner
 import javax.inject.Inject
 
 const val NAV_MENU = "Menu"
@@ -55,43 +57,46 @@ class MainActivity : ComponentActivity() {
                 val backStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = backStackEntry?.destination?.route
 
-                Scaffold(
-                    topBar = {
-                        TopAppBar(
-                            // TODO: Titles should go from strings.xml
-                            title = { Text(text = currentRoute ?: NAV_MENU) },
-                            navigationIcon = {
-                                // Show the home icon only on the main menu
-                                if (currentRoute != NAV_MENU) {
-                                    IconButton(
-                                        onClick = { navController.popBackStack() }
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                                            contentDescription = "Navigate back",
-                                        )
+                // Note the plural in "valueS = " below. The Environment owner provides an array of values.
+                CompositionLocalProvider(values = LocalEnvironmentOwner provides environment) {
+                    Scaffold(
+                        topBar = {
+                            TopAppBar(
+                                // TODO: Titles should go from strings.xml
+                                title = { Text(text = currentRoute ?: NAV_MENU) },
+                                navigationIcon = {
+                                    // Show the home icon only on the main menu
+                                    if (currentRoute != NAV_MENU) {
+                                        IconButton(
+                                            onClick = { navController.popBackStack() }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                                contentDescription = "Navigate back",
+                                            )
+                                        }
                                     }
-                                }
-                            },
-                        )
-                    },
-                    contentWindowInsets = WindowInsets.statusBars,
-                ) { paddings ->
-                    NavHost(
-                        modifier = Modifier.padding(paddings),
-                        navController = navController,
-                        startDestination = NAV_MENU
-                    ) {
-                        composable(NAV_MENU) {
-                            MenuScreen(
-                                onMenuClicked = { navController.navigate(it) }
+                                },
                             )
-                        }
-                        composable(NAV_ADVERTISER) {
-                            AdvertiserScreen()
-                        }
-                        composable(NAV_SCANNER) {
-                            ScannerScreen()
+                        },
+                        contentWindowInsets = WindowInsets.statusBars,
+                    ) { paddings ->
+                        NavHost(
+                            modifier = Modifier.padding(paddings),
+                            navController = navController,
+                            startDestination = NAV_MENU
+                        ) {
+                            composable(NAV_MENU) {
+                                MenuScreen(
+                                    onMenuClicked = { navController.navigate(it) }
+                                )
+                            }
+                            composable(NAV_ADVERTISER) {
+                                AdvertiserScreen()
+                            }
+                            composable(NAV_SCANNER) {
+                                ScannerScreen()
+                            }
                         }
                     }
                 }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/MainActivity.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/MainActivity.kt
@@ -98,9 +98,4 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        environment.close()
-    }
 }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserScreen.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserScreen.kt
@@ -31,33 +31,84 @@
 
 package no.nordicsemi.kotlin.ble.android.sample.advertiser
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
+import no.nordicsemi.kotlin.ble.environment.android.compose.LocalEnvironmentOwner
 
 @Composable
 fun AdvertiserScreen() {
+    val environment = LocalEnvironmentOwner.current
     val vm = hiltViewModel<AdvertiserViewModel>()
-    val state by vm.isAdvertising.collectAsStateWithLifecycle()
+    val state by environment.bluetoothState.collectAsStateWithLifecycle()
+    val isAdvertising by vm.isAdvertising.collectAsStateWithLifecycle()
     val error by vm.error.collectAsStateWithLifecycle()
 
-    AdvertiserView(
-        isAdvertising = state,
-        onStartClicked = vm::startAdvertising,
-        onStopClicked = vm::stopAdvertising,
-        errorMessage = error,
+    Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .verticalScroll(rememberScrollState())
-            .padding(top = 16.dp, bottom = 32.dp),
-        environment = vm.environment,
-    )
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(text = "Bluetooth state: $state")
+
+        // Advertising requires BLUETOOTH_ADVERTISE permission.
+        val permissions = arrayOf(
+            AndroidEnvironment.Permission.BLUETOOTH_ADVERTISE,
+        )
+        var permissionGranted by remember {
+            mutableStateOf(environment.isBluetoothAdvertisePermissionGranted)
+        }
+        val launcher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestMultiplePermissions(),
+            onResult = {
+                // This may not work.
+                // permissionGranted = it.values.all { true }
+                // Use this instead:
+                permissionGranted = environment.isBluetoothAdvertisePermissionGranted
+            }
+        )
+
+        if (permissionGranted) {
+            // Both Bluetooth and Location permissions are granted.
+            // We can now start scanning.
+            AdvertiserView(
+                isAdvertising = isAdvertising,
+                onStartClicked = vm::startAdvertising,
+                onStopClicked = vm::stopAdvertising,
+                errorMessage = error,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState())
+                    .padding(top = 16.dp, bottom = 32.dp),
+                environment = environment,
+            )
+        } else {
+            Button(
+                onClick = {  launcher.launch(permissions) }
+            ) {
+                Text("Grant required permissions")
+            }
+        }
+    }
 }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserView.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserView.kt
@@ -118,7 +118,6 @@ fun AdvertiserView(
             )
 
             AnimatedVisibility(visible = propertiesVisible) {
-
                 Column(
                     modifier = Modifier.padding(vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/advertiser/AdvertiserViewModel.kt
@@ -55,7 +55,6 @@ class AdvertiserViewModel @Inject constructor(
     // We're not using ViewModelScope. For test purposes it's better to create a custom Scope,
     // also connected to the ViewModel lifecycle, but which can be replaced in tests.
     private val scope: CoroutineScope,
-    val environment: AndroidEnvironment,
 ): ViewModel() {
     private val _isAdvertising = MutableStateFlow(false)
     var isAdvertising = _isAdvertising.asStateFlow()

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
@@ -31,6 +31,8 @@
 
 package no.nordicsemi.kotlin.ble.android.sample.scanner
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -47,7 +49,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -58,9 +63,12 @@ import no.nordicsemi.kotlin.ble.android.sample.common.DeviceList
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.android.preview.PreviewPeripheral
 import no.nordicsemi.kotlin.ble.core.ConnectionState
+import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
+import no.nordicsemi.kotlin.ble.environment.android.compose.LocalEnvironmentOwner
 
 @Composable
 fun ScannerScreen() {
+    val environment = LocalEnvironmentOwner.current
     val vm = hiltViewModel<ScannerViewModel>()
     val state by vm.state.collectAsStateWithLifecycle()
     val devices by vm.peripherals.collectAsStateWithLifecycle()
@@ -75,22 +83,51 @@ fun ScannerScreen() {
     ) {
         Text(text = "Bluetooth state: $state")
 
-        // Both Bluetooth and Location permissions are granted.
-        // We can now start scanning.
-        ScannerView(
-            devices = devices,
-            isScanning = isScanning,
-            onStartScan = {
-                if (!isScanning)
-                    vm.onScanRequested()
-                else
-                    vm.onStopScanRequested()
-            },
-            onPeripheralClicked = vm::onPeripheralSelected,
-            onBondRequested = vm::onBondRequested,
-            onRemoveBondRequested = vm::onRemoveBondRequested,
-            onClearCacheRequested = vm::onClearCacheRequested,
+        // Scanning requires BLUETOOTH_SCAN permission, but
+        // reading device name or bond state requires BLUETOOTH_CONNECT permission.
+        val permissions = arrayOf(
+            AndroidEnvironment.Permission.BLUETOOTH_SCAN,
+            AndroidEnvironment.Permission.BLUETOOTH_CONNECT,
         )
+        var permissionGranted by remember {
+            mutableStateOf(environment.isBluetoothScanPermissionGranted && environment.isBluetoothConnectPermissionGranted)
+        }
+        val launcher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestMultiplePermissions(),
+            onResult = {
+                // This may not work.
+                // permissionGranted = it.values.all { true }
+                // Use this instead:
+                permissionGranted = environment.isBluetoothScanPermissionGranted && environment.isBluetoothConnectPermissionGranted
+            }
+        )
+
+        if (permissionGranted) {
+            // Both Bluetooth and Location permissions are granted.
+            // We can now start scanning.
+            ScannerView(
+                devices = devices,
+                isScanning = isScanning,
+                onStartScan = {
+                    if (!isScanning)
+                        vm.onScanRequested()
+                    else
+                        vm.onStopScanRequested()
+                },
+                onPeripheralClicked = vm::onPeripheralSelected,
+                onBondRequested = vm::onBondRequested,
+                onRemoveBondRequested = vm::onRemoveBondRequested,
+                onClearCacheRequested = vm::onClearCacheRequested,
+            )
+        } else {
+            Button(
+                onClick = {
+                    launcher.launch(permissions)
+                }
+            ) {
+                Text("Grant required permissions")
+            }
+        }
     }
 }
 

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
@@ -121,92 +121,10 @@ fun ScannerScreen() {
             )
         } else {
             Button(
-                onClick = {
-                    launcher.launch(permissions)
-                }
+                onClick = {  launcher.launch(permissions) }
             ) {
                 Text("Grant required permissions")
             }
         }
     }
-}
-
-@Composable
-fun ScannerView(
-    devices: List<Peripheral>,
-    isScanning: Boolean,
-    onStartScan: () -> Unit,
-    onPeripheralClicked: (Peripheral) -> Unit,
-    onBondRequested: (Peripheral) -> Unit,
-    onRemoveBondRequested: (Peripheral) -> Unit,
-    onClearCacheRequested: (Peripheral) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Button(
-                onClick = onStartScan,
-                enabled = true,//!isScanning,
-                modifier = Modifier.weight(1f),
-            ) {
-                Text(text = if (isScanning) "Stop scan" else "Start scan")
-            }
-
-            AnimatedVisibility(visible = isScanning) {
-                CircularProgressIndicator(
-                    modifier = Modifier.padding(start = 16.dp),
-                )
-            }
-        }
-
-        if (devices.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(text = "Tap on a device to connect.")
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        HorizontalDivider()
-
-        DeviceList(
-            modifier = Modifier.fillMaxSize(),
-            devices = devices,
-            onItemClick = onPeripheralClicked,
-            onBondRequested = onBondRequested,
-            onRemoveBondRequested = onRemoveBondRequested,
-            onClearCacheRequested = onClearCacheRequested,
-            contentPadding = PaddingValues(bottom = 56.dp, top = 16.dp),
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun ScannerScreenPreview() {
-    val scope = rememberCoroutineScope()
-    ScannerView(
-        devices = listOf(
-            PreviewPeripheral(
-                scope = scope,
-                address = "00:11:22:33:44:55",
-                name = "Device 1",
-                state = ConnectionState.Connected,
-            ),
-            PreviewPeripheral(scope, "11:22:33:44:55:66", "Device 2"),
-            PreviewPeripheral(scope, "22:33:44:55:66:77", "Device 3"),
-        ),
-        isScanning = true,
-        onStartScan = {},
-        onPeripheralClicked = {},
-        onBondRequested = {},
-        onRemoveBondRequested = {},
-        onClearCacheRequested = {},
-    )
 }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerView.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerView.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.android.sample.scanner
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import no.nordicsemi.kotlin.ble.android.sample.common.DeviceList
+import no.nordicsemi.kotlin.ble.client.android.Peripheral
+import no.nordicsemi.kotlin.ble.client.android.preview.PreviewPeripheral
+import no.nordicsemi.kotlin.ble.core.ConnectionState
+
+@Composable
+fun ScannerView(
+    devices: List<Peripheral>,
+    isScanning: Boolean,
+    onStartScan: () -> Unit,
+    onPeripheralClicked: (Peripheral) -> Unit,
+    onBondRequested: (Peripheral) -> Unit,
+    onRemoveBondRequested: (Peripheral) -> Unit,
+    onClearCacheRequested: (Peripheral) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                onClick = onStartScan,
+                enabled = true,//!isScanning,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(text = if (isScanning) "Stop scan" else "Start scan")
+            }
+
+            AnimatedVisibility(visible = isScanning) {
+                CircularProgressIndicator(
+                    modifier = Modifier.padding(start = 16.dp),
+                )
+            }
+        }
+
+        if (devices.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(text = "Tap on a device to connect.")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HorizontalDivider()
+
+        DeviceList(
+            modifier = Modifier.fillMaxSize(),
+            devices = devices,
+            onItemClick = onPeripheralClicked,
+            onBondRequested = onBondRequested,
+            onRemoveBondRequested = onRemoveBondRequested,
+            onClearCacheRequested = onClearCacheRequested,
+            contentPadding = PaddingValues(bottom = 56.dp, top = 16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ScannerScreenPreview() {
+    val scope = rememberCoroutineScope()
+    ScannerView(
+        devices = listOf(
+            PreviewPeripheral(
+                scope = scope,
+                address = "00:11:22:33:44:55",
+                name = "Device 1",
+                state = ConnectionState.Connected,
+            ),
+            PreviewPeripheral(scope, "11:22:33:44:55:66", "Device 2"),
+            PreviewPeripheral(scope, "22:33:44:55:66:77", "Device 3"),
+        ),
+        isScanning = true,
+        onStartScan = {},
+        onPeripheralClicked = {},
+        onBondRequested = {},
+        onRemoveBondRequested = {},
+        onClearCacheRequested = {},
+    )
+}

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -59,6 +59,7 @@ import no.nordicsemi.kotlin.ble.client.android.preview.PreviewPeripheral
 import no.nordicsemi.kotlin.ble.client.distinctByPeripheral
 import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.core.ConnectionState
+import no.nordicsemi.kotlin.ble.core.IncludedService
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PhyInUse
 import no.nordicsemi.kotlin.ble.core.WriteType
@@ -321,7 +322,7 @@ class ScannerViewModel @Inject constructor(
             .onEach { services ->
                 // On each services change, increment the event index.
                 event += 1
-                Timber.i("($event) Services changed: $services")
+                Timber.i("($event) Services changed: ${services?.map { it.uuid to it.isPrimary }}")
             }
             .filterNotNull()
             .onEach { services ->
@@ -393,7 +394,9 @@ class ScannerViewModel @Inject constructor(
                 // Check if LED Button service is available.
                 // If so, blink the LED 5 times.
                 val blinkyServiceUuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
-                val blinkyService = services.firstOrNull { it.uuid == blinkyServiceUuid }
+                val blinkyService = services.firstOrNull {
+                    it.uuid == blinkyServiceUuid && it.isPrimary
+                }
                 blinkyService?.let { service ->
                     val buttonCharacteristicUuid = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
                     val ledCharacteristicUuid = Uuid.parse("00001525-1212-efde-1523-785feabcd123")

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -57,6 +57,7 @@ import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.android.preview.PreviewPeripheral
 import no.nordicsemi.kotlin.ble.client.distinctByPeripheral
+import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PhyInUse
@@ -400,6 +401,8 @@ class ScannerViewModel @Inject constructor(
                     val ledCharacteristic = service.characteristics.firstOrNull { it.uuid == ledCharacteristicUuid }
 
                     Timber.i("($ce) Awaiting for button press to start LED blinking...")
+                    // Note: This may throw InvalidAttributeException if the device gets
+                    //       disconnected or invalidates services during awaiting button press.
                     val result = buttonCharacteristic?.waitForValueChange {
                         Timber.i("($ce) Turning LED on...")
                         ledCharacteristic?.write(byteArrayOf(0x01))
@@ -421,6 +424,15 @@ class ScannerViewModel @Inject constructor(
                             }
                         }
                     }
+                }
+            }
+            .catch {
+                if (it is InvalidAttributeException) {
+                    // InvalidAttributeException is thrown when the peripheral is disconnected
+                    // or services got invalidated when a notification is awaited (waitForValueChange).
+                    Timber.w("Services invalidated during an operation")
+                } else {
+                    Timber.e("Operation failed: ${it.message}")
                 }
             }
             .onCompletion {


### PR DESCRIPTION
This PR:
* Creates a constants with Android Bluetooth permissions values, to allow requesting them in mock environments on older devices,
* Requests `BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT` and `BLUETOOTH_ADVERTISE` permisssions when necessary,
* Fixes sample app by catching the `InvalidAttriburteException` if the device disconnects while awaiting button click.