### PR TITLE
Bugfix: handling included services fixed

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -37,6 +37,7 @@ import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattService
 import androidx.annotation.Keep
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -102,7 +103,14 @@ internal class NativeGattCallback: BluetoothGattCallback() {
             _events.tryEmit(ServicesDiscovered(emptyList()))
             return
         }
-        _events.tryEmit(ServicesDiscovered(services.map { NativeRemoteService(gatt, it, events) }))
+        val remoteServices = services
+            // For some reason, secondary services are not only listed as included services
+            // under the root service, but also on the main list. Skip them.
+            // They will be added as IncludedService inside the NativeRemoteService.
+            .filter { it.type == BluetoothGattService.SERVICE_TYPE_PRIMARY }
+            // Map each primary BluetoothGattService to NativeRemoteService.
+            .map { NativeRemoteService(gatt, it, events) }
+        _events.tryEmit(ServicesDiscovered(remoteServices))
     }
 
     override fun onServiceChanged(gatt: BluetoothGatt) {

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -81,7 +81,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
         logger.debug("onConnectionStateChange: status=$status, newState=$newState")
-        // Pixel 4 with Android 12 does returns status 0 when link is lost to a device.
+        // Pixel 4 with Android 12 does return status 0 when link is lost to a device.
         // Newer versions (Pixel 7 with Android 16) report status 8 (timeout) in the same case.
         val betterStatus = if (
                 newState == BluetoothGatt.STATE_DISCONNECTED &&

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteService.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteService.kt
@@ -67,7 +67,7 @@ class PreviewRemoteService: RemoteService {
 
     override val includedServices: List<RemoteIncludedService>
         get() = definition?.includedServices?.map {
-            PreviewInnerRemoteService(
+            PreviewIncludedRemoteService(
                 service = this,
                 uuid = it.uuid,
                 definition = it,
@@ -146,12 +146,12 @@ class PreviewRemoteService: RemoteService {
 }
 
 @ExperimentalUuidApi
-class PreviewInnerRemoteService internal constructor(
+class PreviewIncludedRemoteService internal constructor(
     override val service: AnyRemoteService,
     override val uuid: Uuid,
     override val instanceId: Int = 0,
     private val definition: ServiceDefinition,
-) : RemoteIncludedService {
+): RemoteIncludedService {
 
     override val characteristics: List<RemoteCharacteristic>
         get() = definition.characteristics.map {
@@ -164,7 +164,7 @@ class PreviewInnerRemoteService internal constructor(
         }
     override val includedServices: List<RemoteIncludedService>
         get() = definition.includedServices.map {
-            PreviewInnerRemoteService(
+            PreviewIncludedRemoteService(
                 service = this,
                 uuid = it.uuid,
                 definition = it,

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/Service.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/Service.kt
@@ -82,12 +82,22 @@ interface AnyService<C: Characteristic<*>>: Service<C> {
      * The owner is set to null when the service was invalidated.
      */
     val owner: Peer<*>?
+
+    /**
+     * Whether the service is a primary service.
+     *
+     * A primary service is a root service that is not included in any other service.
+     */
+    val isPrimary: Boolean
 }
 
 /**
  * An interface representing a primary service.
  */
-interface PrimaryService<C: Characteristic<*>>: AnyService<C>
+interface PrimaryService<C: Characteristic<*>>: AnyService<C> {
+    override val isPrimary: Boolean
+        get() = true
+}
 
 /**
  * An interface representing a service included in another service.
@@ -104,4 +114,7 @@ interface IncludedService<C: Characteristic<*>>: AnyService<C> {
 
     override val owner: Peer<*>?
         get() = service.owner
+
+    override val isPrimary: Boolean
+        get() = false
 }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/common/DeviceServices.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/common/DeviceServices.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import no.nordicsemi.kotlin.ble.client.AnyRemoteService
 import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.RemoteDescriptor
 import no.nordicsemi.kotlin.ble.client.RemoteService
@@ -69,7 +70,7 @@ fun DeviceServices(services: List<RemoteService>?) {
 
 @OptIn(ExperimentalUuidApi::class)
 @Composable
-private fun Service(service: RemoteService) {
+private fun Service(service: AnyRemoteService) {
     Column(
         modifier = Modifier.indent(12.dp, MaterialTheme.colorScheme.primary)
     ) {
@@ -80,6 +81,13 @@ private fun Service(service: RemoteService) {
         if (service.characteristics.isNotEmpty()) {
             service.characteristics.forEach { characteristic ->
                 Characteristic(characteristic)
+
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+        if (service.includedServices.isNotEmpty()) {
+            service.includedServices.forEach { service ->
+                Service(service)
 
                 Spacer(modifier = Modifier.height(4.dp))
             }
@@ -143,6 +151,7 @@ private fun Modifier.indent(strokeWidth: Dp = 12.dp, color: Color): Modifier {
         .padding(start = strokeWidth * 1.25f)
 }
 
+@OptIn(ExperimentalUuidApi::class)
 @Preview(showBackground = true)
 @Composable
 private fun PreviewDeviceServices() {
@@ -155,6 +164,22 @@ private fun PreviewDeviceServices() {
                 Characteristic(0x2A01)
             },
             PreviewRemoteService(0x1801),
+            // LED Button Service
+            PreviewRemoteService(
+                uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123"),
+            ) {
+                // Button Characteristic
+                Characteristic(Uuid.parse("00001524-1212-efde-1523-785feabcd123"), CharacteristicProperty.NOTIFY)
+                // LED Characteristic
+                Characteristic(Uuid.parse("00001525-1212-efde-1523-785feabcd123"), CharacteristicProperty.WRITE_WITHOUT_RESPONSE)
+                // Another LED Button Service inside! What a surprise!
+                IncludedService(
+                    uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+                ) {
+                    Characteristic(Uuid.parse("00001524-1212-efde-1523-785feabcd123"), CharacteristicProperty.NOTIFY)
+                    Characteristic(Uuid.parse("00001525-1212-efde-1523-785feabcd123"), CharacteristicProperty.WRITE_WITHOUT_RESPONSE)
+                }
+            }
         )
     )
 }


### PR DESCRIPTION
This PR fixes the behavior of the library with regards to Included Services (that is GATT Services that are under another service as its "included services").

Apparently, when Android discovers services on a devices with included services, it returns them both as root (incorrectly) and under their parent:
```
Generic Access
Generic Attribute
...
Included Service (B)
Primary Service (A)
- Included Serivce (B)
```

This PR filters out secondary services that were found on the root list of service, as they would be initiated as primary onces.

Also, some other fixes related to included services, i.e. adding `isPrimary` property to `AnyService`.