### PR TITLE
Adding `onSubscription` callback to `subscribe()` to notify when notifications are ready

### DIFF
--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -330,8 +330,6 @@ private class StubRemoteCharacteristic(
         else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
     }
 
-    override fun subscribe(): Flow<ByteArray> = subscribe {}
-
     override suspend fun waitForValueChange(
         rawDataFilter: (ByteArray) -> Boolean,
         merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
@@ -343,9 +341,9 @@ private class StubRemoteCharacteristic(
         .firstOrNull(filter)
         ?: throw InvalidAttributeException()
 
-    private fun subscribe(trigger: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> = when {
+    override fun subscribe(onSubscription: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> = when {
         owner == null -> throw InvalidAttributeException()
-        isSubscribable() -> _value.filter { _isNotifying }.onStart { trigger() }
+        isSubscribable() -> _value.filter { _isNotifying }.onStart { onSubscription() }
         else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
     }
 

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteCharacteristic.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewRemoteCharacteristic.kt
@@ -168,7 +168,9 @@ class PreviewRemoteCharacteristic : RemoteCharacteristic {
 
     override suspend fun write(data: ByteArray, writeType: WriteType) {}
 
-    override fun subscribe(): Flow<ByteArray> = emptyFlow()
+    override fun subscribe(
+        onSubscription: suspend RemoteCharacteristic.() -> Unit
+    ): Flow<ByteArray> = emptyFlow()
 
     override suspend fun waitForValueChange(
         rawDataFilter: (ByteArray) -> Boolean,

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
@@ -34,13 +34,13 @@
 package no.nordicsemi.kotlin.ble.client
 
 import kotlinx.coroutines.flow.Flow
-import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
+import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.ValueDoesNotMatchException
-import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import no.nordicsemi.kotlin.ble.core.Characteristic
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.defaultWriteType
+import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import no.nordicsemi.kotlin.ble.core.util.MergeResult
 import no.nordicsemi.kotlin.ble.core.util.chunked
 import no.nordicsemi.kotlin.ble.core.util.merge
@@ -165,17 +165,29 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * on subscription, that is when a terminal operator (`collect`, `first`, etc.) is invoked on
      * the returned flow.
      *
-     * It is safe to call [setNotify(true)][setNotifying] after calling this method to
-     * synchronically enable notifications on the peripheral before the flow starts getting collected.
+     * [onSubscription] callback is invoked when the notifications or indications have been
+     * enabled successfully.
      *
      * If higher-level packets are sent as multiple notifications or indications, they may be
      * merged using [merge] or [mergeIndexed] operator.
      *
      * ```kotlin
-     * remoteCharacteristic.subscribe()
+     * // The Completable Deferred allows to synchronously await until the notifications are enabled.
+     * val deferred = CompletableDeferred<Unit>()
+     *
+     * // Enable notifications or indications and handle them.
+     * remoteCharacteristic
+     *    .subscribe {
+     *        // Notifications are enabled and being collected.
+     *        deferred.complete(Unit)
+     *    }
+     *    // Catch subscription errors, i.e. OperationFailedException(reason=Subscribe not permitted)
+     * 	  .catch {
+     * 	      deferred.completeExceptionally(it)
+     * 	  }
      *    // If a packet is split into multiple notifications, merge them.
      *    .merge { accumulated, received ->
-     *        // [...]
+     *       // [...]
      *    }
      *    // Transform the response raw data to a meaningful value.
      *    .map { bytes -> parse(bytes) }
@@ -183,15 +195,14 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      *       // [...]
      *    }
      *    .launchIn(scope)
-     * // Optional: Enable notifications
-     * remoteCharacteristic.setNotifying(true)
-     * // Now the flow is collecting and notifications are enabled.
+     * // Synchronously await until the notifications are enabled while still collecting them.
+     * deferred.await()
      * ```
-     * This way no notification or indication will be missed and it is clear when the characteristic
+     * This way no notification or indication will be missed, and it is clear when the characteristic
      * is ready (connected, subscribed, triggered to send data).
      *
-     * If [setNotifying] is skipped, it will be called automatically when the flow collection starts.
-     *
+     * @param onSubscription An optional callback that is invoked when the notifications or
+     * indications have been enabled successfully.
      * @return A flow emitting the raw data of notifications or indications sent from the
      * characteristic when the value changes. The flow completes when the characteristic
      * is invalidated, e.g., when the peripheral disconnects, or sends a Service Changed event.
@@ -206,7 +217,7 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * @see merge
      * @see mergeIndexed
      */
-    fun subscribe(): Flow<ByteArray>
+    fun subscribe(onSubscription: suspend RemoteCharacteristic.() -> Unit = {}): Flow<ByteArray>
 
     /**
      * Waits for the value of the characteristic to change.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -244,27 +244,20 @@ abstract class BaseRemoteCharacteristic(
         }
     }
 
-    final override fun subscribe(): Flow<ByteArray> = subscribe {}
-
     override suspend fun waitForValueChange(
         rawDataFilter: (ByteArray) -> Boolean,
         merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
         filter: (ByteArray) -> Boolean,
         trigger: suspend RemoteCharacteristic.() -> Unit,
-    ): ByteArray {
-        // Check whether the characteristic wasn't invalidated.
-        require(owner != null) {
-            throw InvalidAttributeException()
-        }
+    ): ByteArray = subscribe(trigger)
+        .filter(rawDataFilter)
+        .mergeIndexed(merge)
+        .firstOrNull(filter)
+        ?: throw InvalidAttributeException()
 
-        return subscribe(trigger)
-            .filter(rawDataFilter)
-            .mergeIndexed(merge)
-            .firstOrNull(filter)
-            ?: throw InvalidAttributeException()
-    }
-
-    private fun subscribe(trigger: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> {
+    override fun subscribe(
+        onSubscription: suspend RemoteCharacteristic.() -> Unit
+    ): Flow<ByteArray> {
         // Check whether the characteristic wasn't invalidated.
         require(owner != null) {
             throw InvalidAttributeException()
@@ -279,8 +272,8 @@ abstract class BaseRemoteCharacteristic(
             .onSubscription {
                 // First, make sure the notifications or indications are enabled.
                 setNotifying(true)
-                // Then, invoke the trigger to start the peripheral sending value changes.
-                trigger()
+                // Then, invoke the user callback.
+                onSubscription()
             }
             .takeWhile { !it.isServiceInvalidatedEvent }
             .filterIsInstance(CharacteristicChanged::class)


### PR DESCRIPTION
Before, it was not possible to actually find out when the notifications are enabled and being collected.

The code below would not work, as the notifications could have been enabled before the flow started being collected. That could mean missing some notifications, if they are sent immediately after enabling them.

```kotlin
characteristic.subscribe()
   .onEach {  ... }
   .launchIn(scope)
characteristic.setNotify(true)
```

On the other hand, this code would not allow to pause until the notificaions are enabled:
```kotlin
characteristic.subscribe()
   .onEach {  ... }
   .launchIn(scope)
// They are not enabled here, yet. Enabling happens in `onSubscription` callback upon collection.
```

After the change, a new callbac was added to `subscribe()` to allow catching this:
```kotlin
val deferred = CompletableDeferred<Unit>()
characteristic
   // Subscribe and enable notifications (on collection).
   .subscribe { deferred.complete(Unit) }
   // This will catch an exception thrown when subscribe fails,
   // i.e. OperationFailedException(reason=Subscribe not permitted)
   .catch { deferred.completeExceptionally(it) }
   .onEach { ... }
   .launchIn(this)
deferred.await()
// Now they are both collected and enabled! :)

// We can safely initialize the service.
doMagic()
```