### PR TITLE
[Breaking] `services()` emits a flow of `RemoteServices` events, not just the list of services

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -48,7 +48,9 @@ import no.nordicsemi.kotlin.ble.client.GattEvent
 import no.nordicsemi.kotlin.ble.client.MtuChanged
 import no.nordicsemi.kotlin.ble.client.PhyChanged
 import no.nordicsemi.kotlin.ble.client.ReliableWriteCompleted
+import no.nordicsemi.kotlin.ble.client.RemoteServices
 import no.nordicsemi.kotlin.ble.client.RssiRead
+import no.nordicsemi.kotlin.ble.client.ServiceDiscoveryFailed
 import no.nordicsemi.kotlin.ble.client.ServicesChanged
 import no.nordicsemi.kotlin.ble.client.ServicesDiscovered
 import no.nordicsemi.kotlin.ble.client.internal.CharacteristicChanged
@@ -94,13 +96,18 @@ internal class NativeGattCallback: BluetoothGattCallback() {
 
     override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
         logger.debug("onServicesDiscovered: status=$status")
+        if (status != BluetoothGatt.GATT_SUCCESS) {
+            logger.warn("Services discovery failed with status $status")
+            _events.tryEmit(ServiceDiscoveryFailed(RemoteServices.Failed.Reason.Unknown(status)))
+            return
+        }
         // Expect status to be GATT_SUCCESS (0) and at least 2 services:
         // - Generic Access
         // - Generic Attribute
         val services = gatt.services
-        if (status != BluetoothGatt.GATT_SUCCESS || services.size < 2) {
-            logger.warn("Services discovery failed with status $status")
-            _events.tryEmit(ServicesDiscovered(emptyList()))
+        if (services.size < 2) {
+            logger.warn("Services discovery returned ${services.size} services (>= 2 expected)")
+            _events.tryEmit(ServiceDiscoveryFailed(RemoteServices.Failed.Reason.EmptyResult))
             return
         }
         val remoteServices = services

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -55,6 +55,7 @@ import no.nordicsemi.kotlin.ble.client.MtuChanged
 import no.nordicsemi.kotlin.ble.client.Peripheral
 import no.nordicsemi.kotlin.ble.client.PhyChanged
 import no.nordicsemi.kotlin.ble.client.ReliableWriteCompleted
+import no.nordicsemi.kotlin.ble.client.RemoteServices
 import no.nordicsemi.kotlin.ble.client.ServicesChanged
 import no.nordicsemi.kotlin.ble.client.android.Peripheral.Executor
 import no.nordicsemi.kotlin.ble.client.android.exception.BondingFailedException
@@ -912,8 +913,8 @@ open class Peripheral(
         get() = (newState as? ConnectionState.Disconnected)?.let {
             // Returned error is 0x08 (TIMEOUT).
             it.reason == Reason.LinkLoss &&
-            // This happens before the services are discovered, so the services list is empty,
-            _services.value.isNullOrEmpty() &&
+            // This happens before the services are discovered,
+            _services.value !is RemoteServices.Discovered &&
             // ...but after the app is notified about change to PHY LE 2M.
             phy.value?.txPhy == Phy.PHY_LE_2M
         } ?: false

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
@@ -76,6 +76,13 @@ data class ConnectionStateChanged(val newState: ConnectionState) : GattEvent() {
 data class ServicesDiscovered(val services: List<RemoteService>) : GattEvent()
 
 /**
+ * Event indicating that the service discovery has failed.
+ *
+ * @param reason The reason of the failure.
+ */
+data class ServiceDiscoveryFailed(val reason: RemoteServices.Failed.Reason) : GattEvent()
+
+/**
  * Event indicating that the services have changed.
  */
 data object ServicesChanged : GattEvent()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -108,8 +108,10 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
     val state = _state.asStateFlow()
 
     /** Current list of GATT services. */
-    protected var _services: MutableStateFlow<List<RemoteService>?> = MutableStateFlow(
+    protected var _services: MutableStateFlow<RemoteServices> = MutableStateFlow(
         value = impl.takeIf { it.initialState == ConnectionState.Connected }?.initialServices
+            ?.let { RemoteServices.Discovered(it) }
+            ?: RemoteServices.Unknown
     )
 
     /**
@@ -337,8 +339,8 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * Invalidates current GATT services.
      */
     private fun invalidateServices() {
-        _services.value?.forEach { it.owner = null }
-        _services.update { null }
+        _services.value.invalidate()
+        _services.update { RemoteServices.Unknown }
         servicesDiscovered = false
         if (OperationMutex.holdsLock(ServicesChanged)) {
             try {
@@ -395,16 +397,25 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                 } catch (e: IllegalStateException) {
                     logger.warn(e.message)
                 }
-                if (event.services.isEmpty()) {
-                    logger.warn("Service discovery failed")
-                    invalidateServices()
-                    return
-                }
                 logger.info("Services discovered")
                 _services.update {
                     // Assign the owner to each service, making them valid.
+                    RemoteServices.Discovered(
                     event.services.onEach { it.owner = this }
+                    )
                 }
+            }
+
+            is ServiceDiscoveryFailed -> {
+                try {
+                    // Unlocks the lock locked in `discoverServices` below.
+                    OperationMutex.unlock(ServicesChanged)
+                } catch (e: IllegalStateException) {
+                    logger.warn(e.message)
+                }
+                logger.warn("Service discovery failed")
+                invalidateServices()
+                _services.update { RemoteServices.Failed(event.reason) }
             }
 
             else -> { /* Ignore */ }
@@ -443,6 +454,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                     logger.warn(e.message)
                 }
                 logger.trace("Discovering services")
+                _services.update { RemoteServices.Discovering }
                 impl.discoverServices(uuids)
             }
         }
@@ -481,7 +493,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * or the services have been invalidated.
      */
     @OptIn(ExperimentalUuidApi::class)
-    fun services(uuids: List<Uuid> = emptyList()): StateFlow<List<RemoteService>?> {
+    fun services(uuids: List<Uuid> = emptyList()): StateFlow<RemoteServices> {
         // Mark that service discovery was requested. This is useful when the peripheral
         // reconnects but the services observer was already set.
         serviceDiscoveryRequested = true
@@ -497,16 +509,11 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             return _services.asStateFlow()
         }
 
-        // A method to filter services by UUIDs.
-        fun List<RemoteService>.filterBy(uuids: List<Uuid>): List<RemoteService> {
-            return filter { service -> uuids.any { it == service.uuid } }
-        }
-
         // If there is a filter, create a new flow that will emit filtered services only.
-        val filteredServices = _services.value?.filterBy(uuids)
+        val filteredState = _services.value.filteredBy(uuids)
         return _services
-            .map { it?.filterBy(uuids) }
-            .stateIn(scope, SharingStarted.Lazily, filteredServices)
+            .map { it.filteredBy(uuids) }
+            .stateIn(scope, SharingStarted.Lazily, filteredState)
     }
 
     /**

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -413,7 +413,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                 } catch (e: IllegalStateException) {
                     logger.warn(e.message)
                 }
-                logger.warn("Service discovery failed")
+                logger.warn("Service discovery failed: ${event.reason}")
                 invalidateServices()
                 _services.update { RemoteServices.Failed(event.reason) }
             }
@@ -481,16 +481,41 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
     // Public API implementation
 
     /**
-     * Returns a flow with a list of services discovered on the device.
+     * Returns a flow emitting [RemoteServices] events.
      *
-     * The flow emits `null` when the device is not connected. The list will be updated when the
-     * services are discovered.
+     * ### State machine
+     *
+     * Initially, the state is [Unknown][RemoteServices.Unknown]. Shortly after calling [services]
+     * the flow will emit [Discovering][RemoteServices.Discovering] state, followed by
+     * [Discovered][RemoteServices.Discovered] state, or (unlikely) [Failed][RemoteServices.Failed]
+     * state, where the reason of the failure is given as a parameter
+     * [Failed.reason][RemoteServices.Failed.reason].
+     *
+     * When in [Discovered][RemoteServices.Discovered] or [Failed][RemoteServices.Failed], and the
+     * service will get invalidated, either due to a disconnection or Service Change indication
+     * sent from the remote peripheral, the state will transition to [Unknown][RemoteServices.Unknown].
+     *
+     * Service change will automatically request service discovery, which, when complete, will emit
+     * [Discovered][RemoteServices.Discovered] state with new set of services.
+     *
+     * ```
+     *                           (Initial state)
+     *                                  │
+     *        ┌───────────────>      Unknown     <────────────────┐
+     *        │                         │                         │
+     * (disconnection)     (service discovery started)    (disconnection)
+     *        │                         ↓                         │
+     *     Failed <─────────────── Discovering ────────────> Discovered
+     *
+     * ```
      *
      * @param uuids An optional list of service UUID to filter the results. If empty, all services
      *        will be returned. Some platforms may do partial service discovery and return only
      *        services with given UUIDs.
-     * @return A state flow with the list of services, or `null` if the device is not connected,
-     * or the services have been invalidated.
+     * @return A state flow with the current state of service discovery process. If the method
+     * was called with a [uuids] filter, the [RemoteServices.Discovered] state will contain only
+     * services with given UUIDs, otherwise it will contain all services returned by the
+     * system. If the returned list is empty, the service was not found on the peripheral.
      */
     @OptIn(ExperimentalUuidApi::class)
     fun services(uuids: List<Uuid> = emptyList()): StateFlow<RemoteServices> {

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteServices.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteServices.kt
@@ -1,0 +1,78 @@
+package no.nordicsemi.kotlin.ble.client
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * State of the service discovery process.
+ */
+sealed class RemoteServices {
+
+    /**
+     * Remote services are unknown.
+     *
+     * The service discovery might not have been started initiated, i.e. due to the peripheral not
+     * being connected. This state is also reported when the peripheral invalidates its services
+     * using Service Changed indication, in which case the state should change to [Discovering]
+     * and then to [Discovered] again.
+     *
+     * @see Peripheral.services
+     */
+    data object Unknown : RemoteServices()
+
+    /**
+     * Remote services are being discovered.
+     */
+    data object Discovering : RemoteServices()
+
+    /**
+     * Remote services have been discovered.
+     *
+     * This list contains filtered list of services if [Peripheral.services] was called with a
+     * UUID filter.
+     *
+     * @param services The list of discovered services matching the filter.
+     */
+    data class Discovered(val services: List<RemoteService>) : RemoteServices()
+
+    /**
+     * Remote services discovery has failed.
+     *
+     * @param reason The reason of the failure.
+     */
+    data class Failed(val reason: Reason) : RemoteServices() {
+
+        /**
+         * The reason of service discovery failure.
+         */
+        sealed class Reason {
+            /** Service discovery returned empty list of services. */
+            data object EmptyResult : Reason()
+            /** Service discovery finished with a different status than SUCCESS. */
+            data class Unknown(val status: Int) : Reason()
+        }
+    }
+
+    /**
+     * Invalidates the discovered services.
+     */
+    internal fun invalidate() {
+        if (this is Discovered) {
+            services.forEach { it.owner = null }
+        }
+    }
+
+    /**
+     * Returns filtered service discovery state.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    internal fun filteredBy(uuids: List<Uuid>): RemoteServices = when (this) {
+        is Discovered -> Discovered(
+            services = services.filter { service ->
+                uuids.any { it == service.uuid }
+            }
+        )
+        else -> this
+    }
+
+}

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/common/DeviceServices.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/common/DeviceServices.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.unit.dp
 import no.nordicsemi.kotlin.ble.client.AnyRemoteService
 import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.RemoteDescriptor
-import no.nordicsemi.kotlin.ble.client.RemoteService
+import no.nordicsemi.kotlin.ble.client.RemoteServices
 import no.nordicsemi.kotlin.ble.client.android.preview.PreviewRemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.android.preview.PreviewRemoteDescriptor
 import no.nordicsemi.kotlin.ble.client.android.preview.PreviewRemoteService
@@ -60,10 +60,23 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 @Composable
-fun DeviceServices(services: List<RemoteService>?) {
-    Column {
-        services?.forEach { service ->
-            Service(service)
+fun DeviceServices(services: RemoteServices) {
+    when (services) {
+        is RemoteServices.Unknown -> {
+            Text(text = "Unknown")
+        }
+        is RemoteServices.Discovering -> {
+            Text(text = "Discovering...")
+        }
+        is RemoteServices.Discovered -> {
+            Column {
+                services.services.forEach { service ->
+                    Service(service)
+                }
+            }
+        }
+        is RemoteServices.Failed -> {
+            Text(text = "$services")
         }
     }
 }
@@ -154,43 +167,54 @@ private fun Modifier.indent(strokeWidth: Dp = 12.dp, color: Color): Modifier {
 @OptIn(ExperimentalUuidApi::class)
 @Preview(showBackground = true)
 @Composable
+private fun PreviewDeviceServices_discovery() {
+    DeviceServices(RemoteServices.Discovering)
+}
+
+@OptIn(ExperimentalUuidApi::class)
+@Preview(showBackground = true)
+@Composable
 private fun PreviewDeviceServices() {
     DeviceServices(
-        listOf(
-            PreviewRemoteService(0x1800) {
-                Characteristic(0x2A00, CharacteristicProperty.NOTIFY) {
-                    CharacteristicUserDescriptionDescriptor("Example")
-                }
-                Characteristic(0x2A01)
-            },
-            PreviewRemoteService(0x1801),
-            // LED Button Service
-            PreviewRemoteService(
-                uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123"),
-            ) {
-                // Button Characteristic
-                Characteristic(Uuid.parse("00001524-1212-efde-1523-785feabcd123"), CharacteristicProperty.NOTIFY)
-                // LED Characteristic
-                Characteristic(Uuid.parse("00001525-1212-efde-1523-785feabcd123"), CharacteristicProperty.WRITE_WITHOUT_RESPONSE)
-                // Another LED Button Service inside! What a surprise!
-                IncludedService(
-                    uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+        RemoteServices.Discovered(
+            services = listOf(
+                PreviewRemoteService(0x1800) {
+                    Characteristic(0x2A00, CharacteristicProperty.NOTIFY) {
+                        CharacteristicUserDescriptionDescriptor("Example")
+                    }
+                    Characteristic(0x2A01)
+                },
+                PreviewRemoteService(0x1801),
+                // LED Button Service
+                PreviewRemoteService(
+                    uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123"),
                 ) {
+                    // Button Characteristic
                     Characteristic(Uuid.parse("00001524-1212-efde-1523-785feabcd123"), CharacteristicProperty.NOTIFY)
+                    // LED Characteristic
                     Characteristic(Uuid.parse("00001525-1212-efde-1523-785feabcd123"), CharacteristicProperty.WRITE_WITHOUT_RESPONSE)
+                    // Another LED Button Service inside! What a surprise!
+                    IncludedService(
+                        uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+                    ) {
+                        Characteristic(Uuid.parse("00001524-1212-efde-1523-785feabcd123"), CharacteristicProperty.NOTIFY)
+                        Characteristic(Uuid.parse("00001525-1212-efde-1523-785feabcd123"), CharacteristicProperty.WRITE_WITHOUT_RESPONSE)
+                    }
                 }
-            }
+            )
         )
     )
 }
 
+@OptIn(ExperimentalUuidApi::class)
 @Preview(showBackground = true)
 @Composable
 private fun PreviewCharacteristics() {
     Characteristic(
         characteristic = PreviewRemoteCharacteristic(0x2A00) {
-            Descriptor(0x2901)
-            Descriptor(0x2902)
+            CharacteristicUserDescriptionDescriptor("Description")
+            ClientCharacteristicConfigurationDescriptor()
+            Descriptor(Uuid.random())
         }
     )
 }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -46,12 +46,14 @@ import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import no.nordicsemi.kotlin.ble.client.RemoteServices
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
@@ -321,9 +323,9 @@ class ScannerViewModel @Inject constructor(
             .onEach { services ->
                 // On each services change, increment the event index.
                 event += 1
-                Timber.i("($event) Services changed: ${services?.map { it.uuid to it.isPrimary }}")
+                Timber.i("($event) Services changed: $services")
             }
-            .filterNotNull()
+            .mapNotNull { (it as? RemoteServices.Discovered)?.services }
             .onEach { services ->
                 // Keep the current event fixed in this block.
                 val ce = event


### PR DESCRIPTION
## Breaking changes

This PR introduces some breaking changes in the client API.

Instead of returning an optional list of services, where `null` was used for *services are not available", the flow now emits clear states:
* `Uknown` - when the device is not connected / service discovery was not started.
* `Discovering` - when service discovery is in progress.
* `Discovered` - returning a list of services. This list may be filtered if `services(...)` was called with a list of UUIDs.
* `Failed` - in a rare case when service discovery could fail.

> [!Note]
> If the device disconnects during service disovery the state changes to `Unknown`, not to `Failed`.

### Before

```kotlin
peripheral.services(listOf(myService))
   .onEach { services ->
      // The services was an optional list of `List<RemoteService>?`:
      // null -> not connected / not started
      // empty list -> service not found
      // never called -> on service discovery error
   }
   .launchIn(scope)
```

### After

```kotlin
peripheral.services(listOf(myService))
   .onEach { state ->
      when (state) {
         is RemoteServices.Unknown -> { 
            // Device is not connected, or service discovery was not started
         }
         is RemoteServices.Discovering -> { 
            // Service discovery is in progress
         }
         is RemoteServices.Discovered -> { 
            // Service discovery is complete
            val services = state.services 
            // list of myService -> required service found (1 + instances) 
            // empty list -> service not found
         }
         is RemoteServices.Failed -> { 
            // Service discovery failed
            val reason = state.reason
            // reason -> the reason why discovery failed
         }
      }
   }
   .launchIn(scope)
```