### PR TITLE
Disconnection improvements

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
@@ -64,10 +64,10 @@ internal fun Int.toBondState(): BondState = when (this) {
     else -> BondState.NONE
 }
 
-internal fun Int.toConnectionState(status: Int): ConnectionState = when (this) {
+internal fun Int.toConnectionState(status: Int, reason: ConnectionState.Disconnected.Reason?): ConnectionState = when (this) {
     BluetoothGatt.STATE_CONNECTED -> ConnectionState.Connected
     BluetoothGatt.STATE_CONNECTING -> ConnectionState.Connecting
-    BluetoothGatt.STATE_DISCONNECTED -> ConnectionState.Disconnected(status.toDisconnectionReason())
+    BluetoothGatt.STATE_DISCONNECTED -> ConnectionState.Disconnected(reason ?: status.toDisconnectionReason())
     BluetoothGatt.STATE_DISCONNECTING -> ConnectionState.Disconnecting
     else -> ConnectionState.Disconnected(ConnectionState.Disconnected.Reason.Unknown(this))
 }

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeExecutor.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeExecutor.kt
@@ -43,9 +43,10 @@ import no.nordicsemi.kotlin.ble.client.RemoteService
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
-import no.nordicsemi.kotlin.ble.core.PeripheralType
 import no.nordicsemi.kotlin.ble.core.BondState
 import no.nordicsemi.kotlin.ble.core.ConnectionState
+import no.nordicsemi.kotlin.ble.core.ConnectionState.Disconnected.Reason
+import no.nordicsemi.kotlin.ble.core.PeripheralType
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PhyOption
 import org.jetbrains.annotations.Range
@@ -231,9 +232,9 @@ internal class NativeExecutor(
         return gatt?.readRemoteRssi() ?: false
     }
 
-    override suspend fun disconnect(): Boolean {
+    override suspend fun disconnect(reason: Reason): Boolean {
         gatt?.let { gatt ->
-            gattCallback.disconnectRequest = true
+            gattCallback.disconnectReason = reason
             gatt.disconnect()
             return true
         }
@@ -243,7 +244,7 @@ internal class NativeExecutor(
     override fun close() {
         gatt?.let { gatt ->
             this.gatt = null
-            gattCallback.disconnectRequest = false
+            gattCallback.disconnectReason = null
             try {
                 gatt.disconnect()
             } catch (_: Exception) {

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -59,6 +59,7 @@ import no.nordicsemi.kotlin.ble.client.internal.CharacteristicWrite
 import no.nordicsemi.kotlin.ble.client.internal.DescriptorRead
 import no.nordicsemi.kotlin.ble.client.internal.DescriptorWrite
 import no.nordicsemi.kotlin.ble.core.ConnectionParameters
+import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.PhyInUse
 import org.slf4j.LoggerFactory
 
@@ -70,13 +71,13 @@ internal class NativeGattCallback: BluetoothGattCallback() {
     val events: SharedFlow<GattEvent> = _events.asSharedFlow()
 
     /**
-     * A flag set when the user initiates terminating the connection.
+     * A requested disconnection reason.
      *
      * Older Android versions don't return status=8 (GATT_CONN_TIMEOUT) when the connection
      * drops due to a link loss. By checking whether it was the user who requested disconnection
      * we can improve the status.
      */
-    var disconnectRequest = false
+    var disconnectReason: ConnectionState.Disconnected.Reason? = null
 
     // Handling connection state updates
 
@@ -89,9 +90,9 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         val betterStatus = if (
                 newState == BluetoothGatt.STATE_DISCONNECTED &&
                 status == BluetoothGatt.GATT_SUCCESS &&
-                !disconnectRequest
+                disconnectReason == null
             ) 0x08 /* GATT_CONN_TIMEOUT */ else status
-        _events.tryEmit(ConnectionStateChanged(newState.toConnectionState(betterStatus)))
+        _events.tryEmit(ConnectionStateChanged(newState.toConnectionState(betterStatus, disconnectReason)))
     }
 
     override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -192,8 +192,8 @@ private class StubExecutor(
         return true
     }
 
-    override suspend fun disconnect(): Boolean {
-        _events.emit(ConnectionStateChanged(ConnectionState.Disconnected(Reason.Success)))
+    override suspend fun disconnect(reason: Reason): Boolean {
+        _events.emit(ConnectionStateChanged(ConnectionState.Disconnected(reason)))
         return true
     }
 

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -802,13 +802,15 @@ class PeripheralSpec<ID: Any> private constructor(
          *
          * @throws IllegalStateException when the device is not connected.
          */
-        suspend fun disconnect() {
+        suspend fun disconnect() = disconnect(Reason.Success)
+
+        internal suspend fun disconnect(reason: Reason) {
             val connectionParameters =
                 checkNotNull(connectionParameters) { "Peripheral not connected." }
             val eventHandler = checkNotNull(eventHandler)
 
             delay(connectionParameters.connectionIntervalMillis)
-            _events.emit(ConnectionStateChanged(ConnectionState.Disconnected(Reason.Success)))
+            _events.emit(ConnectionStateChanged(ConnectionState.Disconnected(reason)))
 
             // One virtual client disconnected.
             connectionsCount -= 1

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -65,6 +65,7 @@ import no.nordicsemi.kotlin.ble.core.Peer
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.WriteType
 import org.slf4j.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.uuid.ExperimentalUuidApi
@@ -542,6 +543,16 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             .map { it.filteredBy(uuids) }
             .stateIn(scope, SharingStarted.Lazily, filteredState)
     }
+
+    /**
+     * Suspends until the peripheral is disconnected.
+     *
+     * @throws CancellationException if the current coroutine is canceled.
+     */
+    @IgnorableReturnValue
+    suspend fun awaitDisconnection(): ConnectionState.Disconnected.Reason? = state
+        .filterIsInstance<ConnectionState.Disconnected>()
+        .first().reason
 
     /**
      * The maximum amount of data, in bytes, that can be sent to a characteristic in a single write

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -35,6 +35,7 @@ package no.nordicsemi.kotlin.ble.client
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -53,6 +54,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.PeripheralNotConnectedException
@@ -595,52 +597,75 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * This method does nothing if the peripheral is already disconnected.
      *
+     * Runs in [NonCancellable] coroutine context.
+     *
      * Hint: Use [CentralManager.connect] to connect to the peripheral.
      *
      * @throws SecurityException If BLUETOOTH_CONNECT permission is denied.
      */
-    suspend fun disconnect() {
-        // Depending on the state...
-        when (state.value) {
-            is ConnectionState.Disconnected -> {
-                // Make sure auto-connection is closed.
-                close()
-                return
-            }
-            is ConnectionState.Disconnecting -> {
-                // Skip..
-            }
-            is ConnectionState.Connecting -> {
-                // Cancel the connection attempt.
-                logger.trace("Cancelling connection to {}", this)
-                _state.update { ConnectionState.Disconnecting }
-            }
-            is ConnectionState.Connected -> {
-                // Disconnect from the peripheral.
-                logger.trace("Disconnecting from {}", this)
-                _state.update { ConnectionState.Disconnecting }
-            }
-        }
+    suspend fun disconnect() = disconnect(ConnectionState.Disconnected.Reason.Success)
 
-        // Disconnect and wait until it is disconnected, then close.
-        try {
-            if (!impl.isClosed) {
-                await(
-                    action = { impl.disconnect() },
-                    condition = { it.isDisconnected },
-                    timeout = 500.milliseconds
+    /**
+     * Disconnects the client from the peripheral returning the given parameter as disconnection
+     * reason.
+     *
+     * This method does nothing if the peripheral is already disconnected.
+     *
+     * Runs in [NonCancellable] coroutine context.
+     *
+     * @param reason The reason for disconnection. Use [Success][ConnectionState.Disconnected.Reason.Success]
+     * when disconnection was initiated by the user.
+     */
+    internal suspend fun disconnect(reason: ConnectionState.Disconnected.Reason) = withContext(NonCancellable) {
+        OperationMutex.withLock {
+            // Depending on the state...
+            when (state.value) {
+                is ConnectionState.Disconnected -> {
+                    // Make sure auto-connection is closed.
+                    close()
+                    return@withLock
+                }
+
+                is ConnectionState.Disconnecting -> {
+                    // Skip..
+                }
+
+                is ConnectionState.Connecting -> {
+                    // Cancel the connection attempt.
+                    logger.trace("Cancelling connection to {}", this@Peripheral)
+                    _state.update { ConnectionState.Disconnecting }
+                }
+
+                is ConnectionState.Connected -> {
+                    // Disconnect from the peripheral.
+                    logger.trace("Disconnecting from {}", this@Peripheral)
+                    _state.update { ConnectionState.Disconnecting }
+                }
+            }
+
+            // Disconnect and wait until it is disconnected, then close.
+            try {
+                if (!impl.isClosed) {
+                    await(
+                        action = { impl.disconnect(reason) },
+                        condition = { it.isDisconnected },
+                        timeout = 500.milliseconds
+                    )
+                }
+            } catch (e: TimeoutCancellationException) {
+                if (!isDisconnected) {
+                    logger.warn("Disconnection takes longer than expected, closing")
+                }
+            } finally {
+                close()
+                // If before calling disconnect() the state was not Connected (i.e. Connecting),
+                // the state at this point will be Disconnecting. Change it to Disconnected manually.
+                _state.compareAndSet(
+                    expect = ConnectionState.Disconnecting,
+                    update = ConnectionState.Disconnected(reason)
                 )
+                logger.info("Disconnected from {}", this@Peripheral)
             }
-        } catch (e: TimeoutCancellationException) {
-            if (!isDisconnected) {
-                logger.warn("Disconnection takes longer than expected, closing")
-            }
-        } finally {
-            close()
-            // If before calling disconnect() the state was not Connected (i.e. Connecting),
-            // the state at this point will be Disconnecting. Change it to Disconnected manually.
-            _state.compareAndSet(ConnectionState.Disconnecting, ConnectionState.Disconnected())
-            logger.info("Disconnected from {}", this)
         }
     }
 


### PR DESCRIPTION
This PR adds 2 features:
1. An internal method to specify the disconnection reason with `disconnect(...)` is called. When called with the pubilc API the `Reason.Success` is used, but internally a different reason can be returned.
2. `disconnect()` method now is wrapped in a `withLock { .. }` preventing mutliple concurrent disconnections.