### PR TITLE
Add `FLAG_ACTIVITY_NEW_TASK` flag when enabling Bluetooth from outside of Activity

### DIFF
--- a/environment-android/src/main/java/no/nordicsemi/kotlin/ble/environment/android/NativeAndroidEnvironment.kt
+++ b/environment-android/src/main/java/no/nordicsemi/kotlin/ble/environment/android/NativeAndroidEnvironment.kt
@@ -131,6 +131,7 @@ class NativeAndroidEnvironment private constructor(
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     override fun enableBluetooth() {
         val intent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         applicationContext.startActivity(intent)
     }
 


### PR DESCRIPTION
This PR fixes a crash when Bluetooth is enabled using `NativeAndroidEnvironment` (which has only Application `Context`).
Such `startActivity` must be called with `FLAG_ACTIVITY_NEW_TASK` flag.