### PR TITLE
Profile improvements

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -641,6 +641,15 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * receives Reset button events using `resetButtonEvents`.
      *
      * ```kotlin
+     * // Helper methods.
+     * val RemoteService.heartRateMeasurement: RemoteCharacteristic? = characteristics
+     *    .firstOrNull { it.uuid = HeartRateProfile.heartRateMeasurementUuid }
+     * val RemoteService.heartRateControlPoint: RemoteCharacteristic? = characteristics
+     *    .firstOrNull { it.uuid = HeartRateProfile.heartRateControlPointUuid }
+     * val RemoteService.bodySensorLocation: RemoteCharacteristic? = characteristics
+     *    .firstOrNull { it.uuid = HeartRateProfile.bodySensorLocationUuid }
+     *
+     * // LBS profile implementation.
      * peripheral.profile(
      *    serviceUuid = HeartRateProfile.heartRateServiceUuid,
      *    required = true,
@@ -649,16 +658,15 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *    // 1. Validate the service.
      *
      *    // HRM characteristic is required.
-     *    val hrMeasurement = hrmService.characteristics
-     *       .first { it.uuid = HeartRateProfile.heartRateMeasurementUuid }
+     *    val hrMeasurement = requireNotNull(hrmService.heartRateMeasurement) {
+     *       "HRM characteristic not found"
+     *    }
      *    require(hrMeasurement.isSubscribable()) {
      *       "HRM characteristic must have the NOTIFY property"
      *    }
      *    // Other characteristics are optional.
-     *    val bodySensorLocation = hrmService.characteristics
-     *       .firstOrNull { it.uuid = HeartRateProfile.bodySensorLocationUuid }
-     *    val hrControlPoint = hrmService.characteristics
-     *       .firstOrNull { it.uuid = HeartRateProfile.heartRateControlPointUuid }
+     *    val hrControlPoint = hrmService.heartRateControlPoint
+     *    val bodySensorLocation = hrmService.bodySensorLocation
      *
      *    // 2. Initialize the profile.
      *
@@ -745,8 +753,8 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                             // disconnects (throwing PeripheralNotConnectedException).
                             userJob = scope.launch {
                                 /**
-                                 * A flag set to `false` when a [NoSuchElementException] or
-                                 * [IllegalArgumentException] is thrown from the [block].
+                                 * A flag set to `false` when a [IllegalArgumentException] is
+                                 * thrown from the [block].
                                  *
                                  * This indicates, that the discovered service does not support the
                                  * profile, i.e. is missing a characteristic or a property.
@@ -759,11 +767,11 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                                 try {
                                     block(service)
                                 } catch (e: Exception) {
-                                    // The implementation may use require(...) and first(...) methods
+                                    // The implementation may use require(...) methods
                                     // to verify the service. Catch them and report as if the service
                                     // was not found.
                                     when (e) {
-                                        is IllegalArgumentException, is NoSuchElementException -> {
+                                        is IllegalArgumentException -> {
                                             // Log the stack trace, so origin of the exception is known.
                                             logger.warn("Profile service validation failed", e)
                                             isSupported = false

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -511,7 +511,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *        │                         │                         │
      * (disconnection)     (service discovery started)    (disconnection)
      *        │                         ↓                         │
-     *     Failed <─────────────── Discovering ────────────> Discovered
+     *     Failed <── (failure) ─── Discovering ─── (done) ──> Discovered
      *
      * ```
      *

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -620,16 +620,16 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * Multiple profiles can be added by calling this method once for each service,
      * i.e. Battery Profile and Heart Rate Profile.
      *
-     * The provided [block] is launched as a child coroutine in the given [scope] when a matching
+     * The provided [block] is launched on a child coroutine in the given [scope] when a matching
      * [RemoteService] is emitted by the [services] flow. The launched job is canceled when
      * the peripheral disconnects (the cancellation cause is [PeripheralNotConnectedException])
      * or when the job completes. When the `block` finishes (normally or exceptionally) the
      * peripheral will be disconnected (with the reason [Success][ConnectionState.Disconnected.Reason.Success]).
      *
-     * ## Validation failures
+     * ## Validation
      *
-     * If `block` throws [NoSuchElementException] or [IllegalArgumentException] during service
-     * validation, the connection will be terminated with reason
+     * If `block` throws [IllegalArgumentException] during service validation, the connection will
+     * be terminated with reason
      * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
      *
      * If multiple services share the same [serviceUuid], only the first one is passed to `block`.
@@ -700,9 +700,9 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * ```
      *
      * @param serviceUuid The UUID of the profile service.
-     * @param required Whether the service is required. In example, a Heart Rate app may require
-     * a Heart Rate Service, but also support an optional Battery Service to indicate the battery
-     * level.
+     * @param required Whether the service is required by the app. In example, a Heart Rate app
+     * may require a Heart Rate Service, but also support an optional Battery Service to indicate
+     * the battery level.
      * @param scope The coroutine scope to launch the user block in.
      * @param block The profile implementation.
      */
@@ -712,7 +712,210 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
         required: Boolean = true,
         scope: CoroutineScope,
         block: suspend CoroutineScope.(RemoteService) -> Unit,
+    ) = profile(
+        requiredServiceUuids = listOf(serviceUuid),
+        required = required,
+        scope = scope
+    ) { services ->
+        block(services.first())
+    }
+
+    /**
+     * Registers a profile implementation that runs when the specified GATT service is discovered.
+     *
+     * ## Overview
+     *
+     * Decouples the Bluetooth LE profile interface from application logic, allowing each
+     * device feature (profile) to run in its own coroutine.
+     *
+     * Multiple profiles can be added by calling this method once for each service,
+     * i.e. Battery Profile and Heart Rate Profile.
+     *
+     * Note, that this overload of the `profile` method returns all [RemoteService]s matching
+     * any of the [requiredServiceUuids] or [optionalServiceUuids], even if multiple instances
+     * of the same service were discovered.
+     *
+     * This method suspends only to get the current coroutine scope using [currentCoroutineContext].
+     * The [block] is called in a child coroutine.
+     *
+     * It is safe and recommended to call this method before connecting the peripheral.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * override suspend fun connect(
+     *     block: suspend CoroutineScope.(HeartRateProfile.State) -> Unit,
+     * ): Unit = withContext(Dispatchers.IO) {
+     *     // First, register profile.
+     *     peripheral.profile(
+     *         requiredServiceUuids = listOf(
+     *            ProximityProfile.linkLossServiceUuid
+     *         ),
+     *         optionalServiceUuids = listOf(
+     *            ProximityProfile.immediateAlertServiceUuid,
+     *            ProximityProfile.txPowerServiceUuid,
+     *         ),
+     *         required = true,
+     *     ) { remoteServices ->
+     *         val state = ProximityProfile(remoteServices, this)
+     *
+     *         // Call the block with the Proximity profile state, separating Bluetooth LE from the logic.
+     *         block(state)
+     *     }
+     *     // Connect.
+     *     centralManager.connect(peripheral)
+     *
+     *     // Await disconnection.
+     *     peripheral.awaitDisconnection()
+     * }
+     * ```
+     *
+     * See [profile] for more information.
+     *
+     * @param requiredServiceUuids The list of UUIDs of the GATT services required by the profile.
+     * @param optionalServiceUuids The list of UUIDs of the optional GATT services.
+     * @param required Whether support for this profile is required by the app. In example,
+     * a Heart Rate app may require a Heart Rate Profile, but also support an optional
+     * Battery Profile to indicate the battery level. If `true` (default), and at least one of the
+     * required services is not found on the peripheral, the connection will be terminated with reason
+     * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     * If `false`, the [block] won't be called, but the connection won't be terminated.
+     * @param block The profile implementation.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    suspend fun profile(
+        requiredServiceUuids: List<Uuid>,
+        optionalServiceUuids: List<Uuid> = emptyList(),
+        required: Boolean = true,
+        block: suspend CoroutineScope.(List<RemoteService>) -> Unit,
     ) {
+        // Get the current context. This will allow creating a scope, that will get closed
+        // together with the outer scope.
+        val context = currentCoroutineContext()
+        val userScope = CoroutineScope(context)
+
+        profile(requiredServiceUuids, optionalServiceUuids, required, userScope, block)
+    }
+
+    /**
+     * Registers a profile implementation that runs when the specified GATT services are discovered.
+     *
+     * ## Overview
+     *
+     * Decouples the Bluetooth LE profile interface from application logic, allowing each
+     * device feature (profile) to run in its own coroutine.
+     *
+     * Multiple profiles can be added by calling this method once for each group of services,
+     * i.e. Battery Profile and Heart Rate Profile.
+     *
+     * Note, that this overload of the `profile` method returns all [RemoteService]s matching
+     * any of the [requiredServiceUuids] or [optionalServiceUuids], even if multiple instances
+     * of the same service were discovered.
+     *
+     * The provided [block] is launched on a child coroutine in the given [scope] when all matching
+     * [RemoteService]s are emitted by the [services] flow. The launched job is canceled when
+     * the peripheral disconnects (the cancellation cause is [PeripheralNotConnectedException])
+     * or when the job completes. When the `block` finishes (normally or exceptionally) the
+     * peripheral will be disconnected (with the reason [Success][ConnectionState.Disconnected.Reason.Success]).
+     *
+     * ## Validation
+     *
+     * If `block` throws [IllegalArgumentException] during service validation, the connection will
+     * be terminated with reason
+     * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     *
+     * ## Example
+     *
+     * In this example, the app is connecting to a Heart Rate device with an optional Sensor Location
+     * and HR Control Point characteristics. It updates the UI using `locationFlow` and
+     * receives Reset button events using `resetButtonEvents`.
+     *
+     * ```kotlin
+     * // Helper methods.
+     * val List<RemoteService>.linkLossService: RemoteService? = services
+     *    .firstOrNull { it.uuid = ProximityProfile.linkLossServiceUuid }
+     * val List<RemoteService>.immediateAlertService: RemoteService? = services
+     *    .firstOrNull { it.uuid = ProximityProfile.immediateAlertServiceUuid }
+     * val List<RemoteService>.txPowerService: RemoteService? = services
+     *    .firstOrNull { it.uuid = ProximityProfile.txPowerServiceUuid }
+     *
+     * val RemoteService.alertLevel: RemoteCharacteristic? = characteristics
+     *    .firstOrNull { it.uuid = ProximityProfile.alertLevelUuid }
+     * val RemoteService.txPowerLevel: RemoteCharacteristic? = characteristics
+     *    .firstOrNull { it.uuid = ProximityProfile.txPowerLevelUuid }
+     *
+     * // Proximity profile implementation.
+     * peripheral.profile(
+     *    requiredServiceUuids = listOf(
+     *       ProximityProfile.linkLossServiceUuid
+     *    ),
+     *    optionalServiceUuids = listOf(
+     *       ProximityProfile.immediateAlertServiceUuid,
+     *       ProximityProfile.txPowerServiceUuid,
+     *    ),
+     *    required = true,
+     *    scope = scope,
+     * ) { services ->
+     *    // 1. Validate the services.
+     *
+     *    // Link Loss Service is required.
+     *    val linkLossAlertLevel = requireNotNull(services.linkLossService?.alertLevel) {
+     *       "Link Loss Alert Level characteristic not found"
+     *    }
+     *    require(linkLossAlertLevel.isWritable()) {
+     *       "Link Loss Alert Level characteristic must have the WRITE property"
+     *    }
+     *
+     *    // Other services are optional, but can only be used when both are found.
+     *    val immediateAlertService = services.immediateAlertService
+     *    val txPowerService = services.txPowerService
+     *    val optionalServicesSupported = immediateAlertService != null && txPowerService != null
+     *
+     *    // [...]
+     *
+     *    // 2. Initialize the profile.
+     *
+     *    // Write Link Loss Alert Level.
+     *    linkLossAlertLevel?.write(ProximityProfile.ALERT_HIGH)
+     *
+     *    // Set up immediate alert.
+     *    if (optionalServicesSupported) {
+     *       buttonState
+     *          .onEach {
+     *             immediateAlertService?.alertLevel?.let { level ->
+     *                level.write(ProximityProfile.ALERT_HIGH)
+     *             }
+     *          }
+     *          .launchIn(this)
+     *    }
+     *
+     *    // 3. Await the scope cancellation. The scope will be cancelled when the device disconnects,
+     *    //    or the scope in which this method is called is canceled.
+     *    awaitCancellation()
+     * }
+     * ```
+     *
+     * @param requiredServiceUuids The list of UUIDs of the GATT services required by the profile.
+     * @param optionalServiceUuids The list of UUIDs of the optional GATT services.
+     * @param required Whether support for this profile is required by the app. In example,
+     * a Heart Rate app may require a Heart Rate Profile, but also support an optional
+     * Battery Profile to indicate the battery level. If `true` (default), and at least one of the
+     * required services is not found on the peripheral, the connection will be terminated with reason
+     * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     * If `false`, the [block] won't be called, but the connection won't be terminated.
+     * @param scope The coroutine scope to launch the user block in.
+     * @param block The profile implementation.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun profile(
+        requiredServiceUuids: List<Uuid>,
+        optionalServiceUuids: List<Uuid> = emptyList(),
+        required: Boolean = true,
+        scope: CoroutineScope,
+        block: suspend CoroutineScope.(List<RemoteService>) -> Unit,
+    ) {
+        require(requiredServiceUuids.isNotEmpty()) { "Service UUIDs list cannot be empty" }
+
         /**
          * The user job will be started to execute the user block.
          * It will be canceled when the outer scope is canceled, or when the services get
@@ -726,7 +929,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
          */
         var profileJob: Job? = null
 
-        profileJob = services(listOf(serviceUuid))
+        profileJob = services(requiredServiceUuids + optionalServiceUuids)
             // The services flow will initially emit "Unknown" (as the services are not discovered yet).
             // Upon successful connection the flow will emit "Discovering" followed by:
             // 1. Discovered - when service discovery was successful.
@@ -745,9 +948,11 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         // User scope is continuing observing the services.
                     }
                     is RemoteServices.Discovered -> {
-                        // When services are discovered, check if the profile service exists.
-                        val service = state.services.firstOrNull { it.uuid == serviceUuid }
-                        if (service != null) {
+                        // When services are discovered, check if all required services were discovered.
+                        val missingServices = requiredServiceUuids.filter { serviceUuid ->
+                            state.services.none { service -> service.uuid == serviceUuid }
+                        }
+                        if (missingServices.isEmpty()) {
                             // If the GATT service was found, start the user block in a new job.
                             // This job wil be canceled with the outer scope, or when the peripheral
                             // disconnects (throwing PeripheralNotConnectedException).
@@ -765,7 +970,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                                  */
                                 var isSupported = true
                                 try {
-                                    block(service)
+                                    block(state.services)
                                 } catch (e: Exception) {
                                     // The implementation may use require(...) methods
                                     // to verify the service. Catch them and report as if the service
@@ -798,11 +1003,11 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         } else {
                             // If the required service was not found disconnect, disconnect.
                             if (required) {
-                                logger.warn("Required service $serviceUuid not found")
+                                logger.warn("Required services not supported, missing: $missingServices")
                                 disconnect(ConnectionState.Disconnected.Reason.RequiredServiceNotFound)
                                 profileJob?.cancel()
                             } else {
-                                logger.warn("Optional service $serviceUuid not found")
+                                logger.warn("Optional services not supported, missing: $missingServices")
                                 // Do not disconnect or cancel the user scope.
                                 // The device may change its services and the Discovered state
                                 // may be emitted again.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -548,29 +548,91 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
     }
 
     /**
-     * Adds a profile implementation on the peripheral.
+     * Registers a profile implementation that runs when the specified GATT service is discovered.
      *
      * ## Overview
      *
-     * This method can be used to separate the Bluetooth LE profile interface from the rest of the app.
-     * It allows to split different device features (profiles) in separate coroutines.
+     * Decouples the Bluetooth LE profile interface from application logic, allowing each
+     * device feature (profile) to run in its own coroutine.
      *
-     * This method can be called multiple times for different profiles, i.e. Battery Profile and
-     * Heart Rate Profile.
+     * Multiple profiles can be added by calling this method once for each service,
+     * i.e. Battery Profile and Heart Rate Profile.
      *
-     * The [block] should contain the profile implementation. When the connection is lost, the scope
-     * is canceled with a cause set to [PeripheralNotConnectedException]. When the block completes,
-     * either normally, or exceptionally, the peripheral will get disconnected as if [disconnect]
-     * was closed (with [reason][ConnectionState.Disconnected.reason] set to
-     * [Success][ConnectionState.Disconnected.Reason.Success]).
+     * This method suspends only to get the current coroutine scope using [currentCoroutineContext].
+     * The [block] is called in a child coroutine.
      *
-     * If the block throws a [NoSuchElementException] (using `service.characteristics.first { ... }`)
-     * or [IllegalArgumentException] (using `require(...)`), the connection will be terminated
-     * with the [reason][ConnectionState.Disconnected.reason] set to
+     * It is safe and recommended to call this method before connecting the peripheral.
+     *
+     * ## Example
+     *
+     * ```kotlin
+     * override suspend fun connect(
+     *     block: suspend CoroutineScope.(HeartRateProfile.State) -> Unit,
+     * ): Unit = withContext(Dispatchers.IO) {
+     *     // First, register profile.
+     *     peripheral.profile(
+     *         serviceUuid = HeartRateProfile.heartRateServiceUuid,
+     *         required = true,
+     *     ) { remoteService ->
+     *         val state = HeartRateServiceImpl(remoteService, this)
+     *
+     *         // Call the block with the Heart Rare service state, separating Bluetooth LE from the logic.
+     *         block(state)
+     *     }
+     *     // Connect.
+     *     centralManager.connect(peripheral)
+     *
+     *     // Await disconnection.
+     *     peripheral.awaitDisconnection()
+     * }
+     * ```
+     *
+     * See [profile] for more information.
+     *
+     * @param serviceUuid The UUID of the profile service.
+     * @param required Whether the service is required. In example, a Heart Rate app may require
+     * a Heart Rate Service, but also support an optional Battery Service to indicate the battery
+     * level.
+     * @param block The profile implementation.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    suspend fun profile(
+        serviceUuid: Uuid,
+        required: Boolean = true,
+        block: suspend CoroutineScope.(RemoteService) -> Unit,
+    ) {
+        // Get the current context. This will allow creating a scope, that will get closed
+        // together with the outer scope.
+        val context = currentCoroutineContext()
+        val userScope = CoroutineScope(context)
+
+        profile(serviceUuid, required, userScope, block)
+    }
+
+    /**
+     * Registers a profile implementation that runs when the specified GATT service is discovered.
+     *
+     * ## Overview
+     *
+     * Decouples the Bluetooth LE profile interface from application logic, allowing each
+     * device feature (profile) to run in its own coroutine.
+     *
+     * Multiple profiles can be added by calling this method once for each service,
+     * i.e. Battery Profile and Heart Rate Profile.
+     *
+     * The provided [block] is launched as a child coroutine in the given [scope] when a matching
+     * [RemoteService] is emitted by the [services] flow. The launched job is canceled when
+     * the peripheral disconnects (the cancellation cause is [PeripheralNotConnectedException])
+     * or when the job completes. When the `block` finishes (normally or exceptionally) the
+     * peripheral will be disconnected (with the reason [Success][ConnectionState.Disconnected.Reason.Success]).
+     *
+     * ## Validation failures
+     *
+     * If `block` throws [NoSuchElementException] or [IllegalArgumentException] during service
+     * validation, the connection will be terminated with reason
      * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
      *
-     * If more than one GATT services are discovered with the same [serviceUuid], the [block] will
-     * be called only for the first one found.
+     * If multiple services share the same [serviceUuid], only the first one is passed to `block`.
      *
      * ## Example
      *
@@ -581,7 +643,8 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * ```kotlin
      * peripheral.profile(
      *    serviceUuid = HeartRateProfile.heartRateServiceUuid,
-     *    required = true
+     *    required = true,
+     *    scope = scope,
      * ) { hrmService ->
      *    // 1. Validate the service.
      *
@@ -632,25 +695,30 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * @param required Whether the service is required. In example, a Heart Rate app may require
      * a Heart Rate Service, but also support an optional Battery Service to indicate the battery
      * level.
+     * @param scope The coroutine scope to launch the user block in.
      * @param block The profile implementation.
      */
     @OptIn(ExperimentalUuidApi::class)
-    suspend fun profile(
+    fun profile(
         serviceUuid: Uuid,
         required: Boolean = true,
+        scope: CoroutineScope,
         block: suspend CoroutineScope.(RemoteService) -> Unit,
     ) {
-        // Get the current context. This will allow creating a scope, that will get closed
-        // together with the outer scope.
-        val context = currentCoroutineContext()
-        val userScope = CoroutineScope(context)
-
-        // The user job will be started to execute the user block.
-        // It will be canceled when the outer scope is canceled, or when the services get
-        // invalidated (i.e. on disconnect).
+        /**
+         * The user job will be started to execute the user block.
+         * It will be canceled when the outer scope is canceled, or when the services get
+         * invalidated (i.e. on disconnect).
+         */
         var userJob: Job? = null
 
-        services(listOf(serviceUuid))
+        /**
+         * Profile job collects discovered services and launches the user block when given service
+         * was found.
+         */
+        var profileJob: Job? = null
+
+        profileJob = services(listOf(serviceUuid))
             // The services flow will initially emit "Unknown" (as the services are not discovered yet).
             // Upon successful connection the flow will emit "Discovering" followed by:
             // 1. Discovered - when service discovery was successful.
@@ -675,7 +743,18 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                             // If the GATT service was found, start the user block in a new job.
                             // This job wil be canceled with the outer scope, or when the peripheral
                             // disconnects (throwing PeripheralNotConnectedException).
-                            userJob = userScope.launch {
+                            userJob = scope.launch {
+                                /**
+                                 * A flag set to `false` when a [NoSuchElementException] or
+                                 * [IllegalArgumentException] is thrown from the [block].
+                                 *
+                                 * This indicates, that the discovered service does not support the
+                                 * profile, i.e. is missing a characteristic or a property.
+                                 *
+                                 * In that case, if the profile is [required], the device will get
+                                 * disconnected with reason set to
+                                 * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+                                 */
                                 var isSupported = true
                                 try {
                                     block(service)
@@ -705,7 +784,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                                             ConnectionState.Disconnected.Reason.RequiredServiceNotFound
                                         disconnect(reason)
                                     }
-                                    userScope.cancel()
+                                    profileJob?.cancel()
                                 }
                             }
                         } else {
@@ -713,7 +792,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                             if (required) {
                                 logger.warn("Required service $serviceUuid not found")
                                 disconnect(ConnectionState.Disconnected.Reason.RequiredServiceNotFound)
-                                userScope.cancel()
+                                profileJob?.cancel()
                             } else {
                                 logger.warn("Optional service $serviceUuid not found")
                                 // Do not disconnect or cancel the user scope.
@@ -726,12 +805,12 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         // In case of a service discovery failure, act as if the service was not found.
                         // TODO Is this expected behavior?
                         disconnect(ConnectionState.Disconnected.Reason.RequiredServiceNotFound)
-                        userScope.cancel()
+                        profileJob?.cancel()
                     }
                     else -> { /* Ignore */ }
                 }
             }
-            .launchIn(userScope)
+            .launchIn(scope)
     }
 
     /**

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -36,6 +36,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,7 +44,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNot
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -52,7 +53,11 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import no.nordicsemi.kotlin.ble.android.sample.scanner.profile.LedButtonProfile
+import no.nordicsemi.kotlin.ble.android.sample.scanner.profile.impl.LedButtonServiceImpl
 import no.nordicsemi.kotlin.ble.client.RemoteServices
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.ConnectionPriority
@@ -69,7 +74,6 @@ import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 @HiltViewModel
 class ScannerViewModel @Inject constructor(
@@ -180,12 +184,48 @@ class ScannerViewModel @Inject constructor(
 
                             // The first time the app connects to the peripheral it needs to initiate
                             // observers for various parameters.
-                            // The observers will get cancelled when the connection scope gets cancelled,
+                            // The observers will get canceled when the connection scope gets canceled,
                             // that is when the device is manually disconnected in case of auto connect,
                             // or disconnects for any reason when auto connect was false.
                             observerPhy(peripheral, this)
                             observeConnectionParameters(peripheral, this)
                             observerServices(peripheral, this)
+
+                            installLbsProfile(peripheral, required = false) { state ->
+                                // When the Button is long-clicked, cancel the profile scope.
+                                // This will disconnect the device.
+                                state.buttonLongPressed
+                                    .onEach {
+                                        Timber.w("LBS: Long button press detected, closing profile")
+                                        cancel()
+                                    }
+                                    .launchIn(this)
+
+                                // Tapping Button starts and stops blinking LED.
+                                Timber.v("LBS: Click Button to toggle LED blinking, Long Click to disconnect")
+                                while (isActive) {
+                                    state.buttonPressed.firstOrNull() ?: break
+
+                                    // Blink until the button is pressed again.
+                                    val blinking = launch {
+                                        while (isActive) {
+                                            // We use NonCancellable to make sure the LED doesn't
+                                            // quick-blink when turned off.
+                                            withContext(NonCancellable) {
+                                                state.led.value = true
+                                                delay(250.milliseconds)
+                                                state.led.value = false
+                                                delay(250.milliseconds)
+                                            }
+                                        }
+                                    }
+                                    state.buttonPressed.firstOrNull()
+                                    blinking.cancel()
+                                }
+                                // There's no need to await cancellation, as the loop ends only
+                                // on cancellation.
+                                // awaitCancellation()
+                            }
                         } catch (e: Exception) {
                             Timber.e(e, "Connection attempt failed")
                             connectionScopeMap.remove(peripheral)?.cancel()
@@ -398,48 +438,6 @@ class ScannerViewModel @Inject constructor(
                             }
                         }
                     }
-
-                    // Check if LED Button service is available.
-                    // If so, blink the LED 5 times.
-                    val blinkyServiceUuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
-                    val blinkyService = services.firstOrNull {
-                        it.uuid == blinkyServiceUuid && it.isPrimary
-                    }
-                    blinkyService?.let { service ->
-                        val buttonCharacteristicUuid =
-                            Uuid.parse("00001524-1212-efde-1523-785feabcd123")
-                        val ledCharacteristicUuid =
-                            Uuid.parse("00001525-1212-efde-1523-785feabcd123")
-                        val buttonCharacteristic =
-                            service.characteristics.firstOrNull { it.uuid == buttonCharacteristicUuid }
-                        val ledCharacteristic =
-                            service.characteristics.firstOrNull { it.uuid == ledCharacteristicUuid }
-
-                        Timber.i("($ce) Awaiting for button press to start LED blinking...")
-                        // Note: This may throw InvalidAttributeException if the device gets
-                        //       disconnected or invalidates services during awaiting button press.
-                        val result = buttonCharacteristic?.waitForValueChange {
-                            Timber.i("($ce) Turning LED on...")
-                            ledCharacteristic?.write(byteArrayOf(0x01))
-                        }
-                        Timber.i("($ce) Button change to 0x${result?.toHexString()}")
-
-                        ledCharacteristic?.let { led ->
-                            Timber.i("($ce) Starting to blink LED...")
-                            scope.launch {
-                                try {
-                                    repeat(9) { i ->
-                                        val newValue = byteArrayOf((i % 2).toByte())
-                                        Timber.i("($ce) Writing 0x${newValue.toHexString()} to ${led.uuid}...")
-                                        led.write(newValue)
-                                        delay(250.milliseconds)
-                                    }
-                                } catch (e: Exception) {
-                                    Timber.e("($ce) Failed to write to ${led.uuid}: ${e.message}")
-                                }
-                            }
-                        }
-                    }
                 } catch (_: InvalidAttributeException) {
                     // InvalidAttributeException is thrown when the peripheral is disconnected
                     // or services got invalidated when a notification is awaited (waitForValueChange).
@@ -457,6 +455,22 @@ class ScannerViewModel @Inject constructor(
                 Timber.d("Service collection completed")
             }
             .launchIn(scope)
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    private suspend fun installLbsProfile(
+        peripheral: Peripheral,
+        required: Boolean,
+        block: suspend CoroutineScope.(LedButtonProfile.State) -> Unit,
+    ) {
+        peripheral.profile(
+            serviceUuid = LedButtonProfile.SERVICE_UUID,
+            required = required,
+        ) { lbs ->
+            val state = LedButtonServiceImpl(lbs, scope)
+            Timber.i("LBS: LED Button Service found")
+            block(state)
+        }
     }
 
     private fun observePeripheralState(peripheral: Peripheral, scope: CoroutineScope) {

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/LedButtonProfile.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/LedButtonProfile.kt
@@ -37,11 +37,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
+/**
+ * A definition of the LED Button Service (LBS) profile.
+ *
+ * Read more: [Documentation / Peripheral LBS](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/peripheral_lbs/README.html)
+ */
 @OptIn(ExperimentalUuidApi::class)
 interface LedButtonProfile {
     companion object {
+        /** The LED Button Service UUID. */
         val SERVICE_UUID: Uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+        /** The UUID of the Button characteristic. */
         val BUTTON_CHARACTERISTIC_UUID: Uuid = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
+        /** The UUID of the LED characteristic. */
         val LED_CHARACTERISTIC_UUID: Uuid = Uuid.parse("00001525-1212-efde-1523-785feabcd123")
     }
 

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/LedButtonProfile.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/LedButtonProfile.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.android.sample.scanner.profile
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+interface LedButtonProfile {
+    companion object {
+        val SERVICE_UUID: Uuid = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+        val BUTTON_CHARACTERISTIC_UUID: Uuid = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
+        val LED_CHARACTERISTIC_UUID: Uuid = Uuid.parse("00001525-1212-efde-1523-785feabcd123")
+    }
+
+    /**
+     * The state of the LBS device.
+     *
+     * This interface represents the state of a device with LED Button Service (Blinky) device.
+     */
+    interface State {
+
+        /**
+         * The current state of the LED.
+         *
+         * Set the [value][MutableStateFlow.value] to change the LED state.
+         */
+        val led: MutableStateFlow<Boolean>
+
+        /**
+         * The current state of the button.
+         *
+         * @see buttonPressed
+         * @see buttonLongPressed
+         */
+        val buttonState: StateFlow<Boolean>
+
+        /**
+         * The flow of button click events.
+         *
+         * This flow emits an event when the button is clicked.
+         */
+        val buttonPressed: Flow<Unit>
+
+        /**
+         * The flow of long button clicks events.
+         *
+         * This flow emits an event when the button is pressed for 2 seconds.
+         */
+        val buttonLongPressed: Flow<Unit>
+    }
+}

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.android.sample.scanner.profile.impl
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import no.nordicsemi.kotlin.ble.android.sample.scanner.profile.LedButtonProfile
+import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
+import no.nordicsemi.kotlin.ble.client.RemoteService
+import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
+import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
+import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+import timber.log.Timber
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.ExperimentalUuidApi
+
+@OptIn(ExperimentalUuidApi::class)
+class LedButtonServiceImpl(
+    private val ledButtonService: RemoteService,
+    private val scope: CoroutineScope,
+): LedButtonProfile.State {
+    companion object {
+        val LONG_PRESS_TIMEOUT = 2.seconds
+    }
+
+    init {
+        require(ledButtonService.uuid == LedButtonProfile.SERVICE_UUID) {
+            "Unrecognized service UUID: ${ledButtonService.uuid}"
+        }
+    }
+
+    /**
+     * The GATT characteristics of the LED Button Service (LBS) for controlling the LED state on
+     * the remote peripheral.
+     *
+     * Possible values are:
+     * * 0x00 - LED is off.
+     * * 0x01 - LED is on.
+     * @see LedButtonProfile.LED_CHARACTERISTIC_UUID
+     */
+    private var ledCharacteristic: RemoteCharacteristic = ledButtonService.characteristics
+        .first { it.uuid == LedButtonProfile.LED_CHARACTERISTIC_UUID }
+
+    /**
+     * The GATT characteristics of the LED Button Service (LBS) notified when the Button state on
+     * the remote peripheral changes.
+     *
+     * Possible values are:
+     * * 0x00 - Button is released.
+     * * 0x01 - Button is pressed.
+     * @see LedButtonProfile.BUTTON_CHARACTERISTIC_UUID
+     */
+    private var buttonCharacteristic: RemoteCharacteristic = ledButtonService.characteristics
+        .first { it.uuid == LedButtonProfile.BUTTON_CHARACTERISTIC_UUID }
+
+    init {
+        require(ledCharacteristic.isWritable()) {
+            "LED characteristic must have WRITE or WRITE WITHOUT RESPONSE property"
+        }
+        require(buttonCharacteristic.isSubscribable()) {
+            "Button characteristic must have NOTIFY or INDICATE property"
+        }
+    }
+
+    override val led = MutableStateFlow(false)
+        .also { flow ->
+            scope.launch(Dispatchers.IO) {
+                // Read initial state from the characteristic.
+                try {
+                    val rawLedValue = ledCharacteristic.read()
+                    val isOn = rawLedValue.state
+
+                    // Update the local state.
+                    flow.update { isOn }
+                } catch (e: OperationFailedException) {
+                    // In some implementations the LED characteristic is not readable.
+                    Timber.w("Reading LED characteristic failed: ${e.message}")
+                }
+
+                // Whenever the value changes, write the value to the characteristic.
+                flow.collect { value ->
+                    try {
+                        val command = byteArrayOf(if (value) 1 else 0)
+                        ledCharacteristic.write(command)
+                    } catch (_: InvalidAttributeException) {
+                        // This exception is thrown when the device disconnects, or invalidates services.
+                        Timber.w("Services invalidated when writing to LED characteristic")
+                    } catch (e: OperationFailedException) {
+                        // This exception is thrown when the device disconnects, but the client
+                        // doesn't know about it before writing to the characteristic.
+                        // This usually indicates error 133.
+                        Timber.w("Writing to LED characteristic failed: ${e.message}")
+                    } catch (e: BluetoothException) {
+                        // Other errors.
+                        Timber.e("Writing to LED characteristic failed: ${e.message}")
+                    }
+                }
+            }
+        }
+
+    override val buttonState: StateFlow<Boolean> = MutableStateFlow(false)
+        .also { flow ->
+            scope.launch {
+                try {
+                    // Read initial state from the characteristic.
+                    val rawButtonValue = buttonCharacteristic.read()
+                    val pressed = rawButtonValue.state
+
+                    // Update the local state.
+                    flow.update { pressed }
+                } catch (e: OperationFailedException) {
+                    // In some implementations the Button characteristic is not readable.
+                    Timber.w("Reading button characteristic failed: ${e.message}")
+                }
+
+                // By having a local mutable flow we call subscribe() only once.
+                buttonCharacteristic.subscribe()
+                    .collect { flow.emit(it.state) }
+            }
+        }
+
+    override val buttonPressed: Flow<Unit> = flow {
+        /** Flag set when a long press is detected. */
+        var isLongPress = false
+
+        // Drop the initial value, button state is a StateFlow.
+        buttonState.drop(1).collect { pressed ->
+            // If the button was pressed, start a timeout to detect a long press events.
+            if (pressed) {
+                try {
+                    withTimeout(LONG_PRESS_TIMEOUT) {
+                        // Await the button to be released before the timeout.
+                        buttonState.drop(1).filter { !it }.first()
+                    }
+                } catch (_: TimeoutCancellationException) {
+                    // Button has not been released before the time runed out.
+                    isLongPress = true
+                }
+            } else {
+                // If released, emit the event only if it was not a long press.
+                if (!isLongPress) {
+                    emit(Unit)
+                }
+                isLongPress = false
+            }
+        }
+    }
+
+    override val buttonLongPressed: Flow<Unit> = buttonState
+        .flatMapLatest { pressed ->
+            if (pressed) flow {
+                delay(LONG_PRESS_TIMEOUT)
+                emit(Unit)
+            } else emptyFlow()
+        }
+
+    /**
+     * Parses the raw value of LED and Button (0x00 or 0x01) to [Boolean].
+     *
+     * Note: In LED Button Service both LED and Button use the same state encoding.
+     */
+    private val ByteArray.state: Boolean
+        get() = size == 1 && this[0] == 0x01.toByte()
+}

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
@@ -57,6 +57,17 @@ import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
 
+/**
+ * This class implements the [LedButtonProfile.State] interface.
+ *
+ * The given remote GATT service is validated against the LBS profile requirements:
+ * * Required characteristics (button, LED)
+ * * Required properties (notifications, write, etc.)
+ *
+ * The Bluetooth LE implementation is then exposed as a high-level interface of a device, allowing
+ * to control the device using [led] and [buttonState]. Additional [buttonPressed] and
+ * [buttonLongPressed] events emit when the button is pressed.
+ */
 @OptIn(ExperimentalUuidApi::class)
 class LedButtonServiceImpl(
     private val ledButtonService: RemoteService,


### PR DESCRIPTION
This PR adds a new overload `profile` method to allow setting up a profile using a custom `CoroutineScope`.

Also, the sample app was updated to showcase how to set up a profile. A simple [LED Button Service](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/peripheral_lbs/README.html) was chosen for that.