### PR TITLE
GATT failures improvements

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteCharacteristic.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteCharacteristic.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.kotlin.ble.client.android.internal
 
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothStatusCodes
@@ -40,6 +41,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import no.nordicsemi.kotlin.ble.client.AnyRemoteService
 import no.nordicsemi.kotlin.ble.client.GattEvent
 import no.nordicsemi.kotlin.ble.client.RemoteDescriptor
+import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.internal.BaseRemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.internal.OperationEvent
@@ -81,6 +83,8 @@ internal class NativeRemoteCharacteristic(
     override suspend fun FlowCollector<GattEvent>.executeWrite(data: ByteArray, writeType: WriteType) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val result = gatt.writeCharacteristic(characteristic, data, writeType.toInt())
+
+            @SuppressLint("SwitchIntDef")
             when (result) {
                 BluetoothStatusCodes.SUCCESS -> { /* no-op */ }
 
@@ -90,7 +94,12 @@ internal class NativeRemoteCharacteristic(
                 BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY ->
                     throw OperationFailedException(OperationStatus.BUSY)
 
-                else -> throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                9, /* BluetoothStatusCodes.ERROR_PROFILE_SERVICE_NOT_BOUND */
+                28 /* BluetoothStatusCodes.ERROR_CALLBACK_NOT_REGISTERED */ ->
+                    throw InvalidAttributeException()
+
+                else ->
+                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR, result)
             }
         } else {
             characteristic.value = data

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteDescriptor.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteDescriptor.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 import no.nordicsemi.kotlin.ble.client.GattEvent
 import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
+import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.internal.BaseRemoteDescriptor
 import no.nordicsemi.kotlin.ble.client.internal.OperationEvent
@@ -69,13 +70,20 @@ internal class NativeRemoteDescriptor(
     override suspend fun FlowCollector<GattEvent>.executeWrite(data: ByteArray) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val result = gatt.writeDescriptor(descriptor, data)
+
+            @SuppressLint("SwitchIntDef")
             when (result) {
                 BluetoothStatusCodes.SUCCESS -> { /* no-op */ }
 
                 BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY ->
-                    throw OperationFailedException(OperationStatus.BUSY)
+                    throw OperationFailedException(OperationStatus.BUSY, result)
+
+                9, /* BluetoothStatusCodes.ERROR_PROFILE_SERVICE_NOT_BOUND */
+                28 /* BluetoothStatusCodes.ERROR_CALLBACK_NOT_REGISTERED */ ->
+                    throw InvalidAttributeException()
+
                 else ->
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR, result)
             }
         } else {
             descriptor.value = data

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/ConnectionFailedException.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/ConnectionFailedException.kt
@@ -39,7 +39,7 @@ import no.nordicsemi.kotlin.ble.core.exception.GattException
 /**
  * Thrown when the connection to the peripheral has failed.
  *
- * @property reason The reason why the connection attempt failed.
+ * @property reason The reason of the failure.
  */
 class ConnectionFailedException(
     val reason: ConnectionState.Disconnected.Reason

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/InvalidAttributeException.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/InvalidAttributeException.kt
@@ -34,9 +34,10 @@ package no.nordicsemi.kotlin.ble.client.exception
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 
 /**
- * Thrown when the attribute has been invalidated and cannot be used anymore.
+ * Thrown when the attribute (GATT service, characteristic or a descriptor) has been invalidated
+ * and cannot be used anymore.
  *
- * An attribute may be invalidated when the device has disconnected, the services
+ * An attribute may be invalidated when the device has disconnected, or when the services
  * of the device have changed.
  */
 class InvalidAttributeException: BluetoothException("The attribute has been invalidated and cannot be used anymore")

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/OperationFailedException.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/OperationFailedException.kt
@@ -38,7 +38,9 @@ import no.nordicsemi.kotlin.ble.core.exception.GattException
  * Thrown when the GATT operation failed.
  *
  * @property reason The reason of the failure.
+ * @property errorCode An optional status code of the failure.
  */
 data class OperationFailedException(
-    val reason: OperationStatus
-): GattException("Operation failed: $reason")
+    val reason: OperationStatus,
+    val errorCode: Int? = null,
+): GattException("$reason${if (errorCode != null) " ($errorCode)" else ""}")

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -81,7 +81,6 @@ abstract class BaseRemoteCharacteristic(
      * value have been met (i.e., the characteristic is readable and not invalidated).
      *
      * @receiver The flow collector to emitting GATT events.
-     * @throws CancellationException when any matching event is emitted.
      * @throws OperationFailedException in case the request has failed.
      */
     abstract suspend fun FlowCollector<GattEvent>.executeRead()
@@ -100,6 +99,7 @@ abstract class BaseRemoteCharacteristic(
      * @throws ValueDoesNotMatchException when the value reported by the peripheral
      * is not equal to the value written. This can only happen when *Long Write* is used
      * or the *Reliable Write* procedure is in progress.
+     * @throws InvalidAttributeException when the characteristic has been invalidated.
      */
     abstract suspend fun FlowCollector<GattEvent>.executeWrite(data: ByteArray, writeType: WriteType)
 

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -181,6 +181,9 @@ abstract class BaseRemoteCharacteristic(
                     } catch (e: OperationFailedException) {
                         // This is thrown when the write request failed before it was sent.
                         throw e
+                    } catch (e: InvalidAttributeException) {
+                        // Thrown when the services have been invalidated.
+                        throw e
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.
                         throw BluetoothException(e)
@@ -225,6 +228,9 @@ abstract class BaseRemoteCharacteristic(
                         throw e
                     } catch (e: OperationFailedException) {
                         // This is thrown when the write request failed before it was sent.
+                        throw e
+                    } catch (e: InvalidAttributeException) {
+                        // Thrown when the services have been invalidated.
                         throw e
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -96,6 +96,7 @@ abstract class BaseRemoteDescriptor(
      * @throws ValueDoesNotMatchException when the value reported by the peripheral
      * is not equal to the value written. This can only happen when *Long Write* is used
      * or the *Reliable Write* procedure is in progress.
+     * @throws InvalidAttributeException when the descriptor has been invalidated.
      */
     abstract suspend fun FlowCollector<GattEvent>.executeWrite(data: ByteArray)
 

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -132,6 +132,9 @@ abstract class BaseRemoteDescriptor(
                     } catch (e: OperationFailedException) {
                         // This is thrown when the write request failed before it was sent.
                         throw e
+                    } catch (e: InvalidAttributeException) {
+                        // Thrown when the services have been invalidated.
+                        throw e
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.
                         throw BluetoothException(e)
@@ -175,6 +178,9 @@ abstract class BaseRemoteDescriptor(
                         throw e
                     } catch (e: OperationFailedException) {
                         // This is thrown when the write request failed before it was sent.
+                        throw e
+                    } catch (e: InvalidAttributeException) {
+                        // Thrown when the services have been invalidated.
                         throw e
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.


### PR DESCRIPTION
This PR improves how some write GATT errors are reported to the app.

The errors 9 and 28, which are Android internal, are reported to the apps as if it was OK.
Those are returned when trying to write a value after the device was disconnected, so these get translated to `InvalidAttributeException`.