### PR TITLE
Returning GATT status codes in `OperationFailedException`

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -144,7 +144,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         status: Int
     ) {
         logger.debug("onCharacteristicRead: characteristic={}, value={}, status={}", characteristic.uuid, value.toHexString(), status)
-        _events.tryEmit(CharacteristicRead(characteristic, value, status.toOperationStatus()))
+        _events.tryEmit(CharacteristicRead(characteristic, value, status.toOperationStatus(), status))
     }
 
     override fun onCharacteristicWrite(
@@ -153,7 +153,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         status: Int
     ) {
         logger.debug("onCharacteristicWrite: characteristic={}, status={}", characteristic.uuid, status)
-        _events.tryEmit(CharacteristicWrite(characteristic, status.toOperationStatus()))
+        _events.tryEmit(CharacteristicWrite(characteristic, status.toOperationStatus(), status))
     }
 
     override fun onDescriptorRead(
@@ -163,7 +163,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         value: ByteArray
     ) {
         logger.debug("onDescriptorRead: descriptor={}, value={}, status={}", descriptor.uuid, value.toHexString(), status)
-        _events.tryEmit(DescriptorRead(descriptor, value, status.toOperationStatus()))
+        _events.tryEmit(DescriptorRead(descriptor, value, status.toOperationStatus(), status))
     }
 
     override fun onDescriptorWrite(
@@ -172,14 +172,14 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         status: Int
     ) {
         logger.debug("onDescriptorWrite: descriptor={}, status={}", descriptor.uuid, status)
-        _events.tryEmit(DescriptorWrite(descriptor, status.toOperationStatus()))
+        _events.tryEmit(DescriptorWrite(descriptor, status.toOperationStatus(), status))
     }
 
     // Note, this is called when Reliable Write was executed or aborted.
     // There is no way to distinguish between the two without keeping state.
     override fun onReliableWriteCompleted(gatt: BluetoothGatt, status: Int) {
         logger.debug("onReliableWriteCompleted: status=$status")
-        _events.tryEmit(ReliableWriteCompleted(status.toOperationStatus()))
+        _events.tryEmit(ReliableWriteCompleted(status.toOperationStatus(), status))
     }
 
     // Handling connection parameter updates

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -716,7 +716,7 @@ open class Peripheral(
                         OperationStatus.SUCCESS -> logger.info("Reliable write executed successfully")
                         else -> {
                             logger.warn("Reliable write failed: {}", it.status)
-                            throw OperationFailedException(it.status)
+                            throw OperationFailedException(it.status, it.errorCode)
                         }
                     }
                 } ?: throw PeripheralNotConnectedException()
@@ -758,7 +758,7 @@ open class Peripheral(
                         OperationStatus.SUCCESS -> logger.info("Reliable write aborted successfully")
                         else -> {
                             logger.warn("Aborting reliable write failed: {}", it.status)
-                            throw OperationFailedException(it.status)
+                            throw OperationFailedException(it.status, it.errorCode)
                         }
                     }
                 } ?: throw PeripheralNotConnectedException()

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -182,13 +182,13 @@ private class StubExecutor(
 
     override suspend fun executeReliableWrite(): Boolean {
         isReliableWriteEnabled = false
-        _events.emit(ReliableWriteCompleted(status = OperationStatus.SUCCESS))
+        _events.emit(ReliableWriteCompleted(status = OperationStatus.SUCCESS, 0))
         return true
     }
 
     override suspend fun abortReliableWrite(): Boolean {
         isReliableWriteEnabled = false
-        _events.emit(ReliableWriteCompleted(status = OperationStatus.SUCCESS))
+        _events.emit(ReliableWriteCompleted(status = OperationStatus.SUCCESS, 0))
         return true
     }
 
@@ -303,7 +303,7 @@ private class StubRemoteCharacteristic(
     override suspend fun setNotifying(enabled: Boolean) = when {
         owner == null -> throw InvalidAttributeException()
         isSubscribable() -> _isNotifying = enabled
-        else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
+        else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
     }
 
     override val descriptors: List<RemoteDescriptor> = descriptors
@@ -321,13 +321,13 @@ private class StubRemoteCharacteristic(
     override suspend fun read(): ByteArray = when {
         owner == null -> throw InvalidAttributeException()
         isReadable() -> _value.value
-        else -> throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED)
+        else -> throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED
     }
 
     override suspend fun write(data: ByteArray, writeType: WriteType) = when {
         owner == null -> throw InvalidAttributeException()
         isWritable() -> _value.update { data }
-        else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
+        else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED
     }
 
     override suspend fun waitForValueChange(
@@ -344,7 +344,7 @@ private class StubRemoteCharacteristic(
     override fun subscribe(onSubscription: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> = when {
         owner == null -> throw InvalidAttributeException()
         isSubscribable() -> _value.filter { _isNotifying }.onStart { onSubscription() }
-        else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
+        else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
     }
 
     override fun toString(): String = uuid.toString()
@@ -367,13 +367,13 @@ private class StubRemoteDescriptor(
     override suspend fun read(): ByteArray = when {
         owner == null -> throw InvalidAttributeException()
         isReadable() -> value
-        else -> throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED)
+        else -> throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED
     }
 
     override suspend fun write(data: ByteArray) = when {
         owner == null -> throw InvalidAttributeException()
         isWritable() -> value = data
-        else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
+        else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED
     }
 
     override fun toString(): String = uuid.toString()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
@@ -142,8 +142,9 @@ data class ConnectionParametersChanged(val newParameters: ConnectionParameters) 
  * It ensures that either all prepared writes are committed or none of them.
  *
  * @param status The operation status.
+ * @param errorCode The error code.
  */
-data class ReliableWriteCompleted(val status: OperationStatus) : GattEvent()
+data class ReliableWriteCompleted(val status: OperationStatus, val errorCode: Int) : GattEvent()
 
 /**
  * Event type used by implementations.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/OperationFailedException.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/OperationFailedException.kt
@@ -38,7 +38,7 @@ import no.nordicsemi.kotlin.ble.core.exception.GattException
  * Thrown when the GATT operation failed.
  *
  * @property reason The reason of the failure.
- * @property errorCode An optional status code of the failure.
+ * @property errorCode An optional error code of the failure (if known).
  */
 data class OperationFailedException(
     val reason: OperationStatus,

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -131,12 +131,12 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be subscribed to.
         require(isSubscribable()) {
-            throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
         }
 
         // Check if the CCCD descriptor exists.
         val cccd = descriptors.cccd()
-            ?: throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
+            ?: throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
 
         // Enable handling of notifications or indications locally.
         try {
@@ -166,7 +166,7 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be read.
         require(isReadable()) {
-            throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED)
         }
 
         // Read the characteristic value and await the result.
@@ -196,7 +196,7 @@ abstract class BaseRemoteCharacteristic(
                 ?.let {
                     when (it.status) {
                         OperationStatus.SUCCESS -> it.value
-                        else -> throw OperationFailedException(it.status)
+                        else -> throw OperationFailedException(it.status, it.errorCode)
                     }
                 }
                 ?: throw InvalidAttributeException()
@@ -211,7 +211,7 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be written.
         require(isWritable()) {
-            throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED)
         }
 
         // Write the characteristic value and await the result.
@@ -243,7 +243,7 @@ abstract class BaseRemoteCharacteristic(
                 .firstOrNull()
                 ?.let {
                     check(it.status == OperationStatus.SUCCESS) {
-                        throw OperationFailedException(it.status)
+                        throw OperationFailedException(it.status, it.errorCode)
                     }
                 }
                 ?: throw InvalidAttributeException()
@@ -271,7 +271,7 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be subscribed to.
         require(isSubscribable() && descriptors.cccd() != null) {
-            throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED)
         }
 
         return events

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -119,7 +119,7 @@ abstract class BaseRemoteDescriptor(
 
         // Verify that the descriptor can be read.
         require(isReadable()) {
-            throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED
         }
 
         return OperationMutex.withLock {
@@ -148,7 +148,7 @@ abstract class BaseRemoteDescriptor(
                 ?.let {
                     when (it.status) {
                         OperationStatus.SUCCESS -> it.value
-                        else -> throw OperationFailedException(it.status)
+                        else -> throw OperationFailedException(it.status, it.errorCode)
                     }
                 }
                 ?: throw InvalidAttributeException()
@@ -163,7 +163,7 @@ abstract class BaseRemoteDescriptor(
 
         // Verify that the descriptor can be written to.
         require(isWritable()) {
-            throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED
         }
 
         OperationMutex.withLock {
@@ -194,7 +194,7 @@ abstract class BaseRemoteDescriptor(
                 .firstOrNull()
                 ?.let {
                     check(it.status.isSuccess) {
-                        throw OperationFailedException(it.status)
+                        throw OperationFailedException(it.status, it.errorCode)
                     }
                 }
                 ?: throw InvalidAttributeException()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/GattEvent.kt
@@ -38,7 +38,7 @@ import no.nordicsemi.kotlin.ble.core.OperationStatus
  * GATT event specific to the implementation.
  */
 sealed class OperationEvent(
-    val subject: Any
+    val subject: Any,
 ): ImplSpecificEvent()
 
 class CharacteristicChanged(
@@ -54,6 +54,7 @@ class CharacteristicRead(
     characteristic: Any,
     val value: ByteArray,
     val status: OperationStatus,
+    val errorCode: Int,
 ): OperationEvent(characteristic)
 
 class CharacteristicWrite(
@@ -61,6 +62,7 @@ class CharacteristicWrite(
     //       when mock implementation is used.
     characteristic: Any,
     val status: OperationStatus,
+    val errorCode: Int,
 ): OperationEvent(characteristic)
 
 class DescriptorRead(
@@ -69,6 +71,7 @@ class DescriptorRead(
     descriptor: Any,
     val value: ByteArray,
     val status: OperationStatus,
+    val errorCode: Int,
 ): OperationEvent(descriptor)
 
 class DescriptorWrite(
@@ -76,4 +79,5 @@ class DescriptorWrite(
     //       when mock implementation is used.
     descriptor: Any,
     val status: OperationStatus,
+    val errorCode: Int,
 ): OperationEvent(descriptor)


### PR DESCRIPTION
This PR fixes #275.