### PR TITLE
Logging disconnection also on link loss

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -375,6 +375,9 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                 if (_state.value == event.newState) {
                     return
                 }
+                if (event.disconnected) {
+                    logger.info("Disconnected from {}", this)
+                }
                 _state.update { event.newState }
                 when (event.newState) {
                     is ConnectionState.Connected -> {
@@ -1157,7 +1160,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                     expect = ConnectionState.Disconnecting,
                     update = ConnectionState.Disconnected(reason)
                 )
-                logger.info("Disconnected from {}", this@Peripheral)
             }
         }
     }


### PR DESCRIPTION
Before, the "Disconnected from ..." was logged only after calling `disconnect()`, but wasn't when the device got disconnected for another reason. This PR fixes that.