### PR TITLE
[Breaking] `OperationStatus` changed from *enum* to a *sealed class*

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/Mapper.kt
@@ -195,28 +195,34 @@ internal fun ConnectionPriority.toPriority() = when (this) {
 }
 
 internal fun Int.toOperationStatus(): OperationStatus = when (this) {
-    BluetoothGatt.GATT_SUCCESS -> OperationStatus.SUCCESS
-    BluetoothGatt.GATT_CONNECTION_CONGESTED -> OperationStatus.CONNECTION_CONGESTED
-    BluetoothGatt.GATT_READ_NOT_PERMITTED -> OperationStatus.READ_NOT_PERMITTED
-    BluetoothGatt.GATT_WRITE_NOT_PERMITTED -> OperationStatus.WRITE_NOT_PERMITTED
-    BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION -> OperationStatus.INSUFFICIENT_AUTHENTICATION
-    BluetoothGatt.GATT_INSUFFICIENT_AUTHORIZATION -> OperationStatus.INSUFFICIENT_AUTHORIZATION
-    BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION -> OperationStatus.INSUFFICIENT_ENCRYPTION
-    BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED -> OperationStatus.REQUEST_NOT_SUPPORTED
-    BluetoothGatt.GATT_INVALID_OFFSET -> OperationStatus.INVALID_OFFSET
-    BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH -> OperationStatus.INVALID_ATTRIBUTE_LENGTH
-    0x01 -> OperationStatus.INVALID_HANDLE
-    0x04 -> OperationStatus.INVALID_PDU
-    0x09 -> OperationStatus.PREPARE_QUEUE_FULL
-    0x0A -> OperationStatus.ATTRIBUTE_NOT_FOUND
-    0x0B -> OperationStatus.ATTRIBUTE_NOT_LONG
-    0x0C -> OperationStatus.ENCRYPTION_KEY_TOO_SHORT
-    0x0E -> OperationStatus.UNLIKELY_ERROR
-    0x11 -> OperationStatus.INSUFFICIENT_RESOURCES
-    0x13 -> OperationStatus.VALUE_NOT_ALLOWED
-    133 -> OperationStatus.GATT_ERROR
-    137 -> OperationStatus.INSUFFICIENT_AUTHENTICATION
-    else -> OperationStatus.UNKNOWN_ERROR
+    BluetoothGatt.GATT_SUCCESS -> OperationStatus.Success
+    BluetoothGatt.GATT_CONNECTION_CONGESTED -> OperationStatus.ConnectionCongested
+    BluetoothGatt.GATT_READ_NOT_PERMITTED -> OperationStatus.ReadNotPermitted
+    BluetoothGatt.GATT_WRITE_NOT_PERMITTED -> OperationStatus.WriteNotPermitted
+    BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION -> OperationStatus.InsufficientAuthentication
+    BluetoothGatt.GATT_INSUFFICIENT_AUTHORIZATION -> OperationStatus.InsufficientAuthorization
+    BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION -> OperationStatus.InsufficientEncryption
+    BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED -> OperationStatus.RequestNotSupported
+    BluetoothGatt.GATT_INVALID_OFFSET -> OperationStatus.InvalidOffset
+    BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH -> OperationStatus.InvalidAttributeLength
+    0x93 /* BluetoothGatt.GATT_CONNECTION_TIMEOUT, API 35+ */ -> OperationStatus.ConnectionTimeout
+    0x01 -> OperationStatus.InvalidHandle
+    0x04 -> OperationStatus.InvalidPdu
+    0x09 -> OperationStatus.PrepareQueueFull
+    0x0A -> OperationStatus.AttributeNotFound
+    0x0B -> OperationStatus.AttributeNotLong
+    0x0C -> OperationStatus.EncryptionKeyTooShort
+    0x0E -> OperationStatus.UnlikelyError
+    0x11 -> OperationStatus.InsufficientResources
+    0x13 -> OperationStatus.ValueNotAllowed
+    0x85 -> OperationStatus.GattError
+    in 0x80..0x9F -> OperationStatus.ApplicationError(this)
+    0xFC -> OperationStatus.WriteRequestRejected
+    0xFD -> OperationStatus.ClientCharacteristicConfigurationDescriptorImproperlyConfigured
+    0xFE -> OperationStatus.ProcedureAlreadyInProgress
+    0xFF -> OperationStatus.OutOfRange
+    in 0xE0..0xFF -> OperationStatus.ProfileError(this)
+    else -> OperationStatus.UnknownError(this)
 }
 
 internal fun WriteType.toInt() = when (this) {

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -144,7 +144,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         status: Int
     ) {
         logger.debug("onCharacteristicRead: characteristic={}, value={}, status={}", characteristic.uuid, value.toHexString(), status)
-        _events.tryEmit(CharacteristicRead(characteristic, value, status.toOperationStatus(), status))
+        _events.tryEmit(CharacteristicRead(characteristic, value, status.toOperationStatus()))
     }
 
     override fun onCharacteristicWrite(
@@ -153,7 +153,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         status: Int
     ) {
         logger.debug("onCharacteristicWrite: characteristic={}, status={}", characteristic.uuid, status)
-        _events.tryEmit(CharacteristicWrite(characteristic, status.toOperationStatus(), status))
+        _events.tryEmit(CharacteristicWrite(characteristic, status.toOperationStatus()))
     }
 
     override fun onDescriptorRead(
@@ -163,7 +163,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         value: ByteArray
     ) {
         logger.debug("onDescriptorRead: descriptor={}, value={}, status={}", descriptor.uuid, value.toHexString(), status)
-        _events.tryEmit(DescriptorRead(descriptor, value, status.toOperationStatus(), status))
+        _events.tryEmit(DescriptorRead(descriptor, value, status.toOperationStatus()))
     }
 
     override fun onDescriptorWrite(
@@ -172,14 +172,14 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         status: Int
     ) {
         logger.debug("onDescriptorWrite: descriptor={}, status={}", descriptor.uuid, status)
-        _events.tryEmit(DescriptorWrite(descriptor, status.toOperationStatus(), status))
+        _events.tryEmit(DescriptorWrite(descriptor, status.toOperationStatus()))
     }
 
     // Note, this is called when Reliable Write was executed or aborted.
     // There is no way to distinguish between the two without keeping state.
     override fun onReliableWriteCompleted(gatt: BluetoothGatt, status: Int) {
         logger.debug("onReliableWriteCompleted: status=$status")
-        _events.tryEmit(ReliableWriteCompleted(status.toOperationStatus(), status))
+        _events.tryEmit(ReliableWriteCompleted(status.toOperationStatus()))
     }
 
     // Handling connection parameter updates

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteCharacteristic.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteCharacteristic.kt
@@ -68,14 +68,14 @@ internal class NativeRemoteCharacteristic(
     override fun setCharacteristicNotification(enabled: Boolean) {
         val success = gatt.setCharacteristicNotification(characteristic, enabled)
         check(success) {
-            throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+            throw OperationFailedException(OperationStatus.RequestFailed)
         }
     }
 
     override suspend fun FlowCollector<GattEvent>.executeRead() {
         val success = gatt.readCharacteristic(characteristic)
         check(success) {
-            throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+            throw OperationFailedException(OperationStatus.RequestFailed)
         }
     }
 
@@ -89,24 +89,24 @@ internal class NativeRemoteCharacteristic(
                 BluetoothStatusCodes.SUCCESS -> { /* no-op */ }
 
                 BluetoothStatusCodes.ERROR_GATT_WRITE_NOT_ALLOWED ->
-                    throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED)
+                    throw OperationFailedException(OperationStatus.WriteNotPermitted)
 
                 BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY ->
-                    throw OperationFailedException(OperationStatus.BUSY)
+                    throw OperationFailedException(OperationStatus.Busy)
 
                 9, /* BluetoothStatusCodes.ERROR_PROFILE_SERVICE_NOT_BOUND */
                 28 /* BluetoothStatusCodes.ERROR_CALLBACK_NOT_REGISTERED */ ->
                     throw InvalidAttributeException()
 
                 else ->
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR, result)
+                    throw OperationFailedException(OperationStatus.UnknownError(result))
             }
         } else {
             characteristic.value = data
             characteristic.writeType = writeType.toInt()
             val success = gatt.writeCharacteristic(characteristic)
             check(success) {
-                throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                throw OperationFailedException(OperationStatus.RequestFailed)
             }
         }
     }

--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteDescriptor.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeRemoteDescriptor.kt
@@ -62,7 +62,7 @@ internal class NativeRemoteDescriptor(
     override suspend fun FlowCollector<GattEvent>.executeRead() {
         val success = gatt.readDescriptor(descriptor)
         check(success) {
-            throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+            throw OperationFailedException(OperationStatus.RequestFailed)
         }
     }
 
@@ -76,14 +76,14 @@ internal class NativeRemoteDescriptor(
                 BluetoothStatusCodes.SUCCESS -> { /* no-op */ }
 
                 BluetoothStatusCodes.ERROR_GATT_WRITE_REQUEST_BUSY ->
-                    throw OperationFailedException(OperationStatus.BUSY, result)
+                    throw OperationFailedException(OperationStatus.Busy)
 
                 9, /* BluetoothStatusCodes.ERROR_PROFILE_SERVICE_NOT_BOUND */
                 28 /* BluetoothStatusCodes.ERROR_CALLBACK_NOT_REGISTERED */ ->
                     throw InvalidAttributeException()
 
                 else ->
-                    throw OperationFailedException(OperationStatus.UNKNOWN_ERROR, result)
+                    throw OperationFailedException(OperationStatus.UnknownError(result))
             }
         } else {
             descriptor.value = data
@@ -94,7 +94,7 @@ internal class NativeRemoteDescriptor(
                 BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
             val success = gatt.writeDescriptor(descriptor)
             check(success) {
-                throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                throw OperationFailedException(OperationStatus.RequestFailed)
             }
         }
     }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/Peripheral.kt
@@ -483,7 +483,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.readPhy()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }
@@ -526,7 +526,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.requestPhy(txPhy, rxPhy, phyOptions)) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }
@@ -603,7 +603,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.requestMtu(ATT_MTU_MAX)) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }
@@ -640,7 +640,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.requestConnectionPriority(priority)) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }
@@ -705,7 +705,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.executeReliableWrite()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }
@@ -713,10 +713,10 @@ open class Peripheral(
                 // TODO add .timeout(...)?
                 .firstOrNull()?.let {
                     when (it.status) {
-                        OperationStatus.SUCCESS -> logger.info("Reliable write executed successfully")
+                        OperationStatus.Success -> logger.info("Reliable write executed successfully")
                         else -> {
                             logger.warn("Reliable write failed: {}", it.status)
-                            throw OperationFailedException(it.status, it.errorCode)
+                            throw OperationFailedException(it.status)
                         }
                     }
                 } ?: throw PeripheralNotConnectedException()
@@ -747,7 +747,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.abortReliableWrite()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }
@@ -755,10 +755,10 @@ open class Peripheral(
                 // TODO add .timeout(...)?
                 .firstOrNull()?.let {
                     when (it.status) {
-                        OperationStatus.SUCCESS -> logger.info("Reliable write aborted successfully")
+                        OperationStatus.Success -> logger.info("Reliable write aborted successfully")
                         else -> {
                             logger.warn("Aborting reliable write failed: {}", it.status)
-                            throw OperationFailedException(it.status, it.errorCode)
+                            throw OperationFailedException(it.status)
                         }
                     }
                 } ?: throw PeripheralNotConnectedException()
@@ -796,7 +796,7 @@ open class Peripheral(
             impl.events
                 .onSubscription {
                     if (!impl.refreshCache()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 // TODO add .timeout(...)?
@@ -821,7 +821,7 @@ open class Peripheral(
             impl.bondState
                 .onSubscription {
                     if (!impl.createBond()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 // Skip the initial state. It should transition to BONDING quickly.
@@ -861,7 +861,7 @@ open class Peripheral(
             impl.bondState
                 .onSubscription {
                     if (!impl.removeBond()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .first { it == BondState.NONE }

--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/preview/PreviewPeripheral.kt
@@ -182,13 +182,13 @@ private class StubExecutor(
 
     override suspend fun executeReliableWrite(): Boolean {
         isReliableWriteEnabled = false
-        _events.emit(ReliableWriteCompleted(status = OperationStatus.SUCCESS, 0))
+        _events.emit(ReliableWriteCompleted(status = OperationStatus.Success))
         return true
     }
 
     override suspend fun abortReliableWrite(): Boolean {
         isReliableWriteEnabled = false
-        _events.emit(ReliableWriteCompleted(status = OperationStatus.SUCCESS, 0))
+        _events.emit(ReliableWriteCompleted(status = OperationStatus.Success))
         return true
     }
 
@@ -303,7 +303,7 @@ private class StubRemoteCharacteristic(
     override suspend fun setNotifying(enabled: Boolean) = when {
         owner == null -> throw InvalidAttributeException()
         isSubscribable() -> _isNotifying = enabled
-        else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
+        else -> throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
     }
 
     override val descriptors: List<RemoteDescriptor> = descriptors
@@ -321,13 +321,13 @@ private class StubRemoteCharacteristic(
     override suspend fun read(): ByteArray = when {
         owner == null -> throw InvalidAttributeException()
         isReadable() -> _value.value
-        else -> throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED
+        else -> throw OperationFailedException(OperationStatus.ReadNotPermitted)
     }
 
     override suspend fun write(data: ByteArray, writeType: WriteType) = when {
         owner == null -> throw InvalidAttributeException()
         isWritable() -> _value.update { data }
-        else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED
+        else -> throw OperationFailedException(OperationStatus.WriteNotPermitted)
     }
 
     override suspend fun waitForValueChange(
@@ -344,7 +344,7 @@ private class StubRemoteCharacteristic(
     override fun subscribe(onSubscription: suspend RemoteCharacteristic.() -> Unit): Flow<ByteArray> = when {
         owner == null -> throw InvalidAttributeException()
         isSubscribable() -> _value.filter { _isNotifying }.onStart { onSubscription() }
-        else -> throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
+        else -> throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
     }
 
     override fun toString(): String = uuid.toString()
@@ -367,13 +367,13 @@ private class StubRemoteDescriptor(
     override suspend fun read(): ByteArray = when {
         owner == null -> throw InvalidAttributeException()
         isReadable() -> value
-        else -> throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED
+        else -> throw OperationFailedException(OperationStatus.ReadNotPermitted)
     }
 
     override suspend fun write(data: ByteArray) = when {
         owner == null -> throw InvalidAttributeException()
         isWritable() -> value = data
-        else -> throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED
+        else -> throw OperationFailedException(OperationStatus.WriteNotPermitted)
     }
 
     override fun toString(): String = uuid.toString()

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -1041,7 +1041,7 @@ class PeripheralSpec<ID: Any> private constructor(
             val eventHandler = checkNotNull(eventHandler)
             when (val response = eventHandler.onExecuteWriteRequest(execute)) {
                 is WriteResponse.Success -> {
-                    _events.emit(ReliableWriteCompleted(OperationStatus.SUCCESS))
+                    _events.emit(ReliableWriteCompleted(OperationStatus.Success))
                 }
 
                 is WriteResponse.Failure -> {

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockRemoteCharacteristic.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockRemoteCharacteristic.kt
@@ -86,7 +86,7 @@ class MockRemoteCharacteristic(
                 characteristic = this@MockRemoteCharacteristic,
                 value = byteArrayOf(),
                 // TODO Verify if this is the correct status to use.
-                status = OperationStatus.INVALID_HANDLE,
+                status = OperationStatus.InvalidHandle,
             ))
             return
         }
@@ -100,8 +100,8 @@ class MockRemoteCharacteristic(
         val status = when {
             insecure ||
             authenticationRequired && peripheralSpec.isBonded -> null
-            authenticationRequired -> OperationStatus.INSUFFICIENT_AUTHENTICATION
-            else -> OperationStatus.READ_NOT_PERMITTED
+            authenticationRequired -> OperationStatus.InsufficientAuthentication
+            else -> OperationStatus.ReadNotPermitted
         }
         status?.let { status ->
             // The response is delivered in the next connection interval.
@@ -149,7 +149,7 @@ class MockRemoteCharacteristic(
                 emit(CharacteristicRead(
                     characteristic = this@MockRemoteCharacteristic,
                     value = truncatedData,
-                    status = OperationStatus.SUCCESS,
+                    status = OperationStatus.Success,
                 ))
             }
             is ReadResponse.Failure -> {
@@ -177,7 +177,7 @@ class MockRemoteCharacteristic(
                     emit(CharacteristicWrite(
                         characteristic = this@MockRemoteCharacteristic,
                         // TODO Verify if this is the correct status to use.
-                        status = OperationStatus.INVALID_HANDLE,
+                        status = OperationStatus.InvalidHandle,
                     ))
                     return
                 }
@@ -191,8 +191,8 @@ class MockRemoteCharacteristic(
                 val status = when {
                     insecure ||
                     authenticationRequired && peripheralSpec.isBonded -> null
-                    authenticationRequired -> OperationStatus.INSUFFICIENT_AUTHENTICATION
-                    else -> OperationStatus.WRITE_NOT_PERMITTED
+                    authenticationRequired -> OperationStatus.InsufficientAuthentication
+                    else -> OperationStatus.WriteNotPermitted
                 }
                 status?.let { status ->
                     // The response is delivered in the next connection interval.
@@ -239,7 +239,7 @@ class MockRemoteCharacteristic(
                                 val match = truncatedData.contentEquals(response.value)
                                 // When not in Reliable Write, Long Write automatically executes or
                                 // aborts all prepared writes.
-                                var status = OperationStatus.SUCCESS
+                                var status: OperationStatus = OperationStatus.Success
                                 if (!useReliableWrite) {
                                     when (val response = eventHandler.onExecuteWriteRequest(match)) {
                                         is WriteResponse.Success -> { /* no-op */ }
@@ -281,7 +281,7 @@ class MockRemoteCharacteristic(
                                 delay(duration)
                                 emit(CharacteristicWrite(
                                     characteristic = this@MockRemoteCharacteristic,
-                                    status = OperationStatus.SUCCESS,
+                                    status = OperationStatus.Success,
                                 ))
                             }
 
@@ -324,7 +324,7 @@ class MockRemoteCharacteristic(
                 // release it by emitting the event.
                 emit(CharacteristicWrite(
                     characteristic = this@MockRemoteCharacteristic,
-                    status = OperationStatus.SUCCESS,
+                    status = OperationStatus.Success,
                 ))
             }
         }

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockRemoteDescriptor.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockRemoteDescriptor.kt
@@ -79,7 +79,7 @@ class MockRemoteDescriptor(
                 descriptor = this@MockRemoteDescriptor,
                 value = byteArrayOf(),
                 // TODO Verify if this is the correct status to use.
-                status = OperationStatus.INVALID_HANDLE,
+                status = OperationStatus.InvalidHandle,
             ))
             return
         }
@@ -93,8 +93,8 @@ class MockRemoteDescriptor(
         val status = when {
             insecure ||
                     authenticationRequired && peripheralSpec.isBonded -> null
-            authenticationRequired -> OperationStatus.INSUFFICIENT_AUTHENTICATION
-            else -> OperationStatus.READ_NOT_PERMITTED
+            authenticationRequired -> OperationStatus.InsufficientAuthentication
+            else -> OperationStatus.ReadNotPermitted
         }
         status?.let { status ->
             // The response is delivered in the next connection interval.
@@ -124,7 +124,7 @@ class MockRemoteDescriptor(
                 emit(DescriptorRead(
                         descriptor = this@MockRemoteDescriptor,
                         value = truncatedData,
-                        status = OperationStatus.SUCCESS,
+                        status = OperationStatus.Success,
                     )
                 )
             }
@@ -151,7 +151,7 @@ class MockRemoteDescriptor(
             emit(DescriptorWrite(
                 descriptor = this@MockRemoteDescriptor,
                 // TODO Verify if this is the correct status to use.
-                status = OperationStatus.INVALID_HANDLE,
+                status = OperationStatus.InvalidHandle,
             ))
             return
         }
@@ -165,8 +165,8 @@ class MockRemoteDescriptor(
         val status = when {
             insecure ||
             authenticationRequired && peripheralSpec.isBonded -> null
-            authenticationRequired -> OperationStatus.INSUFFICIENT_AUTHENTICATION
-            else -> OperationStatus.WRITE_NOT_PERMITTED
+            authenticationRequired -> OperationStatus.InsufficientAuthentication
+            else -> OperationStatus.WriteNotPermitted
         }
         status?.let { status ->
             // The response is delivered in the next connection interval.
@@ -222,7 +222,7 @@ class MockRemoteDescriptor(
                             is WriteResponse.Success -> {
                                 emit(CharacteristicWrite(
                                     characteristic = this@MockRemoteDescriptor,
-                                    status = OperationStatus.SUCCESS,
+                                    status = OperationStatus.Success,
                                 ))
                             }
                             is WriteResponse.Failure -> {
@@ -266,12 +266,12 @@ class MockRemoteDescriptor(
                         delay(duration)
                         emit(DescriptorWrite(
                             descriptor = this@MockRemoteDescriptor,
-                            status = OperationStatus.SUCCESS,
+                            status = OperationStatus.Success,
                         ))
                     }
                     is WriteResponse.Failure -> {
                         when (result.status) {
-                            OperationStatus.BUSY -> throw OperationFailedException(OperationStatus.BUSY)
+                            OperationStatus.Busy -> throw OperationFailedException(OperationStatus.Busy)
                             else -> { /* continue */ }
                         }
                         // The read response is delivered in the next connection interval.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
@@ -142,9 +142,8 @@ data class ConnectionParametersChanged(val newParameters: ConnectionParameters) 
  * It ensures that either all prepared writes are committed or none of them.
  *
  * @param status The operation status.
- * @param errorCode The error code.
  */
-data class ReliableWriteCompleted(val status: OperationStatus, val errorCode: Int) : GattEvent()
+data class ReliableWriteCompleted(val status: OperationStatus) : GattEvent()
 
 /**
  * Event type used by implementations.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -1073,7 +1073,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             impl.events
                 .onSubscription {
                     if (!impl.readRssi()) {
-                        throw OperationFailedException(OperationStatus.UNKNOWN_ERROR)
+                        throw OperationFailedException(OperationStatus.RequestFailed)
                     }
                 }
                 .takeWhile { !it.isDisconnectionEvent }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/OperationFailedException.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/exception/OperationFailedException.kt
@@ -38,9 +38,7 @@ import no.nordicsemi.kotlin.ble.core.exception.GattException
  * Thrown when the GATT operation failed.
  *
  * @property reason The reason of the failure.
- * @property errorCode An optional error code of the failure (if known).
  */
 data class OperationFailedException(
     val reason: OperationStatus,
-    val errorCode: Int? = null,
-): GattException("$reason${if (errorCode != null) " ($errorCode)" else ""}")
+): GattException(reason.toString())

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -131,12 +131,12 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be subscribed to.
         require(isSubscribable()) {
-            throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
+            throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
         }
 
         // Check if the CCCD descriptor exists.
         val cccd = descriptors.cccd()
-            ?: throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED
+            ?: throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
 
         // Enable handling of notifications or indications locally.
         try {
@@ -166,7 +166,7 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be read.
         require(isReadable()) {
-            throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.ReadNotPermitted)
         }
 
         // Read the characteristic value and await the result.
@@ -195,8 +195,8 @@ abstract class BaseRemoteCharacteristic(
                 .firstOrNull()
                 ?.let {
                     when (it.status) {
-                        OperationStatus.SUCCESS -> it.value
-                        else -> throw OperationFailedException(it.status, it.errorCode)
+                        OperationStatus.Success -> it.value
+                        else -> throw OperationFailedException(it.status)
                     }
                 }
                 ?: throw InvalidAttributeException()
@@ -211,7 +211,7 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be written.
         require(isWritable()) {
-            throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED)
+            throw OperationFailedException(OperationStatus.WriteNotPermitted)
         }
 
         // Write the characteristic value and await the result.
@@ -242,8 +242,8 @@ abstract class BaseRemoteCharacteristic(
                 .filter { it.matches() }
                 .firstOrNull()
                 ?.let {
-                    check(it.status == OperationStatus.SUCCESS) {
-                        throw OperationFailedException(it.status, it.errorCode)
+                    check(it.status == OperationStatus.Success) {
+                        throw OperationFailedException(it.status)
                     }
                 }
                 ?: throw InvalidAttributeException()
@@ -271,7 +271,7 @@ abstract class BaseRemoteCharacteristic(
 
         // Verify that the characteristic can be subscribed to.
         require(isSubscribable() && descriptors.cccd() != null) {
-            throw OperationFailedException(OperationStatus.SUBSCRIBE_NOT_PERMITTED, 0x6) // BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED)
+            throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
         }
 
         return events

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -119,7 +119,7 @@ abstract class BaseRemoteDescriptor(
 
         // Verify that the descriptor can be read.
         require(isReadable()) {
-            throw OperationFailedException(OperationStatus.READ_NOT_PERMITTED, 0x2) // BluetoothGatt.GATT_READ_NOT_PERMITTED
+            throw OperationFailedException(OperationStatus.ReadNotPermitted)
         }
 
         return OperationMutex.withLock {
@@ -147,8 +147,8 @@ abstract class BaseRemoteDescriptor(
                 .firstOrNull()
                 ?.let {
                     when (it.status) {
-                        OperationStatus.SUCCESS -> it.value
-                        else -> throw OperationFailedException(it.status, it.errorCode)
+                        OperationStatus.Success -> it.value
+                        else -> throw OperationFailedException(it.status)
                     }
                 }
                 ?: throw InvalidAttributeException()
@@ -163,7 +163,7 @@ abstract class BaseRemoteDescriptor(
 
         // Verify that the descriptor can be written to.
         require(isWritable()) {
-            throw OperationFailedException(OperationStatus.WRITE_NOT_PERMITTED, 0x3) // BluetoothGatt.GATT_WRITE_NOT_PERMITTED
+            throw OperationFailedException(OperationStatus.WriteNotPermitted)
         }
 
         OperationMutex.withLock {
@@ -194,7 +194,7 @@ abstract class BaseRemoteDescriptor(
                 .firstOrNull()
                 ?.let {
                     check(it.status.isSuccess) {
-                        throw OperationFailedException(it.status, it.errorCode)
+                        throw OperationFailedException(it.status)
                     }
                 }
                 ?: throw InvalidAttributeException()

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/GattEvent.kt
@@ -54,7 +54,6 @@ class CharacteristicRead(
     characteristic: Any,
     val value: ByteArray,
     val status: OperationStatus,
-    val errorCode: Int,
 ): OperationEvent(characteristic)
 
 class CharacteristicWrite(
@@ -62,7 +61,6 @@ class CharacteristicWrite(
     //       when mock implementation is used.
     characteristic: Any,
     val status: OperationStatus,
-    val errorCode: Int,
 ): OperationEvent(characteristic)
 
 class DescriptorRead(
@@ -71,7 +69,6 @@ class DescriptorRead(
     descriptor: Any,
     val value: ByteArray,
     val status: OperationStatus,
-    val errorCode: Int,
 ): OperationEvent(descriptor)
 
 class DescriptorWrite(
@@ -79,5 +76,4 @@ class DescriptorWrite(
     //       when mock implementation is used.
     descriptor: Any,
     val status: OperationStatus,
-    val errorCode: Int,
 ): OperationEvent(descriptor)

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/OperationStatus.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/OperationStatus.kt
@@ -42,80 +42,124 @@ package no.nordicsemi.kotlin.ble.core
  * Read more in Bluetooth Specification, Vol 3 (Host), Part F (ATT), 3.4.1.1 ATT_ERROR_RSP:
  * [link](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-62/out/en/host/attribute-protocol--att-.html#UUID-eefd3e8d-9b16-3af8-1fb4-fa90f52262e8).
  */
-enum class OperationStatus {
+sealed class OperationStatus(
+    open val code: Int,
+) {
     /** A GATT operation completed successfully. */
-    SUCCESS, // 0x00
+    object Success: OperationStatus(0x00)
     /** The attribute handle given was not valid on this server. */
-    INVALID_HANDLE, // 0x01
+    object InvalidHandle: OperationStatus(0x01)
     /**GATT read operation is not permitted. */
-    READ_NOT_PERMITTED, // 0x02
+    object ReadNotPermitted: OperationStatus(0x02)
     /** GATT write operation is not permitted. */
-    WRITE_NOT_PERMITTED, // 0x03
+    object WriteNotPermitted: OperationStatus(0x03)
     /** The attribute PDU was invalid. */
-    INVALID_PDU, // 0x04
+    object InvalidPdu: OperationStatus(0x04)
     /** Insufficient authentication for a given operation. */
-    INSUFFICIENT_AUTHENTICATION, // 0x05
+    object InsufficientAuthentication: OperationStatus(0x05)
     /** The given request is not supported. */
-    REQUEST_NOT_SUPPORTED, // 0x06
+    object RequestNotSupported: OperationStatus(0x06)
     /** A read or write operation was requested with an invalid offset. */
-    INVALID_OFFSET, // 0x07
+    object InvalidOffset: OperationStatus(0x07)
     /**Insufficient authorization for a given operation. */
-    INSUFFICIENT_AUTHORIZATION, // x08
+    object InsufficientAuthorization: OperationStatus(0x08)
     /** The prepare write queue is full. */
-    PREPARE_QUEUE_FULL, // 0x09
+    object PrepareQueueFull: OperationStatus(0x09)
     /** No attribute found within the given attribute handle range. */
-    ATTRIBUTE_NOT_FOUND, // 0x0A
+    object AttributeNotFound: OperationStatus(0x0A)
     /** The attribute cannot be read using the *Long Read* procedure. */
-    ATTRIBUTE_NOT_LONG, // 0x0B
+    object AttributeNotLong: OperationStatus(0x0B)
     /** The Encryption Key Size used for encrypting this link is too short. */
-    ENCRYPTION_KEY_TOO_SHORT, // 0x0C
+    object EncryptionKeyTooShort: OperationStatus(0x0C)
     /** A write operation exceeds the maximum length of the attribute. */
-    INVALID_ATTRIBUTE_LENGTH, // 0x0D
+    object InvalidAttributeLength: OperationStatus(0x0D)
     /** The attribute request that was requested has encountered an error that was unlikely, and therefore could not be completed as requested. */
-    UNLIKELY_ERROR, // 0x0E
+    object UnlikelyError: OperationStatus(0x0E)
     /** Insufficient encryption for a given operation. */
-    INSUFFICIENT_ENCRYPTION, // 0x0F
+    object InsufficientEncryption: OperationStatus(0x0F)
     /** Insufficient Resources to complete the request. */
-    INSUFFICIENT_RESOURCES, // 0x11
+    object InsufficientResources: OperationStatus(0x10)
     /** The attribute parameter value was not allowed. */
-    VALUE_NOT_ALLOWED, // 0x13
-    /** The characteristic does not support subscribing for value change. */
-    SUBSCRIBE_NOT_PERMITTED,
+    object ValueNotAllowed: OperationStatus(0x13)
+
+    /**
+     * A generic application level error.
+     *
+     * Application Errors have [code]s in range 0x80 - 0x9F.
+     */
+    open class ApplicationError(override val code: Int): OperationStatus(code)
     /** A remote device connection is congested. */
-    CONNECTION_CONGESTED, // 0x8F
-    /** Device is busy. */
-    BUSY,
+    object ConnectionCongested: ApplicationError(0x8F)
     /** Most generic GATT error code. */
-    GATT_ERROR,
+    object GattError: ApplicationError(0x85) // 133
+    /**
+     * GATT connection timed out, likely due to the remote device being out of range or not
+     * advertising as connectable.
+     */
+    object ConnectionTimeout: ApplicationError(0x93)
+
+    /**
+     * Common Profile and Service Error Codes.
+     *
+     * Profile and Service Errors have [code]s in range 0xE0 – 0xFF.
+     *
+     * Those are defined in Core Specification Supplement, Volume 1, Part B.
+     */
+    open class ProfileError(override val code: Int): OperationStatus(code)
+    /** Write Request Rejected. */
+    object WriteRequestRejected: ProfileError(0xFC)
+    /** Client Characteristic Configuration Descriptor Improperly Configured. */
+    object ClientCharacteristicConfigurationDescriptorImproperlyConfigured: ProfileError(0xFD)
+    /** Procedure Already in Progress. */
+    object ProcedureAlreadyInProgress: ProfileError(0xFE)
+    /** Out of Range. */
+    object OutOfRange: ProfileError(0xFF)
+
     /** Unknown error. */
-    UNKNOWN_ERROR;
+    data class UnknownError(override val code: Int): OperationStatus(code)
+
+    // These errors are mapped from non-Bluetooth status codes.
+
+    /** An unknown internal error occurred when executing the operation. */
+    object RequestFailed: OperationStatus(-1)
+    /** Device is busy. */
+    object Busy: OperationStatus(-2)
+    /** The characteristic does not support subscribing for value change. */
+    object SubscribeNotPermitted: OperationStatus(-3)
 
     val isSuccess
-        get() = this == SUCCESS
+        get() = this is Success
 
     override fun toString() = when (this) {
-        SUCCESS -> "Success"
-        INVALID_HANDLE -> "Invalid handle"
-        READ_NOT_PERMITTED -> "Read not permitted"
-        WRITE_NOT_PERMITTED -> "Write not permitted"
-        INVALID_ATTRIBUTE_LENGTH -> "Invalid attribute length"
-        INVALID_OFFSET -> "Invalid offset"
-        SUBSCRIBE_NOT_PERMITTED -> "Subscribe not permitted"
-        REQUEST_NOT_SUPPORTED -> "Request not supported"
-        PREPARE_QUEUE_FULL -> "Prepare queue full"
-        INSUFFICIENT_ENCRYPTION -> "Insufficient encryption"
-        INSUFFICIENT_AUTHENTICATION -> "Insufficient authentication"
-        INSUFFICIENT_AUTHORIZATION -> "Insufficient authorization"
-        INSUFFICIENT_RESOURCES -> "Insufficient resources"
-        INVALID_PDU -> "Invalid PDU"
-        ATTRIBUTE_NOT_FOUND -> "Attribute not found"
-        ATTRIBUTE_NOT_LONG -> "Attribute not long"
-        ENCRYPTION_KEY_TOO_SHORT -> "Encryption key too short"
-        VALUE_NOT_ALLOWED -> "Value not allowed"
-        UNLIKELY_ERROR -> "Unlikely error"
-        BUSY -> "Busy"
-        CONNECTION_CONGESTED -> "Connection congested"
-        GATT_ERROR -> "GATT error"
-        UNKNOWN_ERROR -> "Unknown error"
+        Success -> "Success"
+        InvalidHandle -> "Invalid Handle"
+        ReadNotPermitted -> "Read Not Permitted"
+        WriteNotPermitted -> "Write Not Permitted"
+        InvalidPdu -> "Invalid PDU"
+        InsufficientAuthentication -> "Insufficient Authentication"
+        RequestNotSupported -> "Request Not Supported"
+        InvalidOffset -> "Invalid Offset"
+        InsufficientAuthorization -> "Insufficient Authorization"
+        PrepareQueueFull -> "Prepare Queue Full"
+        AttributeNotFound -> "Attribute Not Found"
+        AttributeNotLong -> "Attribute Not Long"
+        EncryptionKeyTooShort -> "Encryption Key Too Short"
+        InvalidAttributeLength -> "Invalid Attribute Length"
+        UnlikelyError -> "Unlikely Error"
+        InsufficientEncryption -> "Insufficient Encryption"
+        InsufficientResources -> "Insufficient Resources"
+        ValueNotAllowed -> "Value Not Allowed"
+        ConnectionCongested -> "Connection Congested"
+        GattError -> "Gatt Error"
+        is ApplicationError -> "Application Error (code: ${code.toHexString()})"
+        WriteRequestRejected -> "Write Request Rejected"
+        ClientCharacteristicConfigurationDescriptorImproperlyConfigured -> "Client Characteristic Configuration Descriptor Improperly Configured"
+        ProcedureAlreadyInProgress -> "Procedure Already In Progress"
+        OutOfRange -> "Out of Range"
+        is ProfileError -> "Profile Error (code: ${code.toHexString()})"
+        is UnknownError -> "Unknown Error (code: ${code.toHexString()})"
+        RequestFailed -> "Request Failed"
+        Busy -> "Busy"
+        SubscribeNotPermitted -> "Subscribe Not Permitted"
     }
 }

--- a/sample/src/mock/java/no/nordicsemi/kotlin/ble/android/sample/di/ViewModelModule.kt
+++ b/sample/src/mock/java/no/nordicsemi/kotlin/ble/android/sample/di/ViewModelModule.kt
@@ -209,7 +209,7 @@ object ViewModelModule {
             when (characteristic.instanceId) {
                 buttonHandle -> ReadResponse.Success(isButtonPressed.toBytes())
                 ledHandle -> ReadResponse.Success(isLedOn.toBytes())
-                else -> ReadResponse.Failure(OperationStatus.READ_NOT_PERMITTED)
+                else -> ReadResponse.Failure(OperationStatus.ReadNotPermitted)
             }
     }
 


### PR DESCRIPTION
This PR fixes #275 in a better way than #277 tried (and failed).

The `OperationStatus` was refactored from an *enum* to a *sealed class*, allowing to use `UnknownError` with an error code. Also, each known status got a code. A new `OperationStatus.ApplicationError` and `OperationStatus.ProfileError` classes should be used for respective errors (see [spec](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-62/out/en/host/attribute-protocol--att-.html#UUID-5a07e398-0e4d-af25-0243-2b45ebfbda5b)).

Worth noting, that `RequestFailed`, `Busy` and `SubscribeNotPermitted` are returned by the library and have no underlying meaningful codes, hence the `code` is a negative number.

`RequestFailed` is returned when the API method failed without giving any failure (i.e. returned `false`).