### PR TITLE
[Bugfix] Fixed handling service invalidation in `profile`

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -58,6 +57,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.PeripheralNotConnectedException
 import no.nordicsemi.kotlin.ble.client.internal.OperationMutex
@@ -926,13 +926,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
          */
         var userJob: Job? = null
 
-        /**
-         * Profile job collects discovered services and launches the user block when given service
-         * was found.
-         */
-        var profileJob: Job? = null
-
-        profileJob = services(requiredServiceUuids + optionalServiceUuids)
+        services(requiredServiceUuids + optionalServiceUuids)
             // The services flow will initially emit "Unknown" (as the services are not discovered yet).
             // Upon successful connection the flow will emit "Discovering" followed by:
             // 1. Discovered - when service discovery was successful.
@@ -945,8 +939,10 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             .onEach { state ->
                 when (state) {
                     is RemoteServices.Unknown -> {
-                        // When the device gets disconnected, cancel the user job (if running).
-                        userJob?.cancel(CancellationException(PeripheralNotConnectedException()))
+                        // When the services get invalidated, of the device gets disconnected,
+                        // cancel the user job (if running).
+                        val cause = if (isConnected) InvalidAttributeException() else PeripheralNotConnectedException()
+                        userJob?.cancel(CancellationException(cause))
                         // Do not cancel the user scope here. The device may get reconnected.
                         // User scope is continuing observing the services.
                     }
@@ -957,58 +953,37 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         }
                         if (missingServices.isEmpty()) {
                             // If the GATT service was found, start the user block in a new job.
-                            // This job wil be canceled with the outer scope, or when the peripheral
-                            // disconnects (throwing PeripheralNotConnectedException).
+                            // This job will be canceled with the outer scope, or when the peripheral
+                            // disconnects (throwing InvalidAttributeException).
                             userJob = scope.launch {
-                                /**
-                                 * A flag set to `false` when a [IllegalArgumentException] is
-                                 * thrown from the [block].
-                                 *
-                                 * This indicates, that the discovered service does not support the
-                                 * profile, i.e. is missing a characteristic or a property.
-                                 *
-                                 * In that case, if the profile is [required], the device will get
-                                 * disconnected with reason set to
-                                 * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
-                                 */
-                                var isSupported = true
                                 try {
                                     block(state.services)
+                                    disconnect()
                                 } catch (e: Exception) {
-                                    // The implementation may use require(...) methods
-                                    // to verify the service. Catch them and report as if the service
-                                    // was not found.
                                     when (e) {
+                                        // The implementation may use require(...) methods
+                                        // to verify the service.
+                                        // Catch them and report as if the service was not found.
                                         is IllegalArgumentException -> {
-                                            // Log the stack trace, so origin of the exception is known.
-                                            logger.warn("Profile service validation failed", e)
-                                            isSupported = false
+                                            logger.warn("Profile validation failed", e)
+                                            if (required) {
+                                                disconnect(ConnectionState.Disconnected.Reason.RequiredServiceNotFound)
+                                            }
                                         }
-                                        else -> throw e
+                                        else -> {
+                                            logger.error("Profile block failed", e)
+                                            throw e
+                                        }
                                     }
                                 } finally {
                                     userJob = null
-                                    // Don't disconnect if an optional service failed validation.
-                                    val optionalNotSupported = !isSupported && !required
-                                    if (!optionalNotSupported) {
-                                        // Disconnect when user has finished with the profile.
-                                        // Assume, that any possible auto-connect is not used, as then
-                                        // user would have not finished with the profile.
-                                        val reason = if (isSupported)
-                                            ConnectionState.Disconnected.Reason.Success
-                                        else
-                                            ConnectionState.Disconnected.Reason.RequiredServiceNotFound
-                                        disconnect(reason)
-                                    }
-                                    profileJob?.cancel()
                                 }
                             }
                         } else {
-                            // If the required service was not found disconnect, disconnect.
+                            // If any required service was not found disconnect, disconnect.
                             if (required) {
                                 logger.warn("Required services not supported, missing: $missingServices")
                                 disconnect(ConnectionState.Disconnected.Reason.RequiredServiceNotFound)
-                                profileJob?.cancel()
                             } else {
                                 logger.warn("Optional services not supported, missing: $missingServices")
                                 // Do not disconnect or cancel the user scope.
@@ -1021,7 +996,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         // In case of a service discovery failure, act as if the service was not found.
                         // TODO Is this expected behavior?
                         disconnect(ConnectionState.Disconnected.Reason.RequiredServiceNotFound)
-                        profileJob?.cancel()
                     }
                     else -> { /* Ignore */ }
                 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -121,7 +121,7 @@ abstract class BaseRemoteCharacteristic(
 
     final override suspend fun setNotifying(enabled: Boolean) {
         // Check whether the characteristic wasn't invalidated.
-        require(owner != null) {
+        requireNotNull(owner) {
             throw InvalidAttributeException()
         }
 
@@ -160,7 +160,7 @@ abstract class BaseRemoteCharacteristic(
 
     final override suspend fun read(): ByteArray {
         // Check whether the characteristic wasn't invalidated.
-        require(owner != null) {
+        requireNotNull(owner) {
             throw InvalidAttributeException()
         }
 
@@ -205,7 +205,7 @@ abstract class BaseRemoteCharacteristic(
 
     final override suspend fun write(data: ByteArray, writeType: WriteType) {
         // Check whether the characteristic wasn't invalidated.
-        require(owner != null) {
+        requireNotNull(owner) {
             throw InvalidAttributeException()
         }
 
@@ -265,7 +265,7 @@ abstract class BaseRemoteCharacteristic(
         onSubscription: suspend RemoteCharacteristic.() -> Unit
     ): Flow<ByteArray> {
         // Check whether the characteristic wasn't invalidated.
-        require(owner != null) {
+        requireNotNull(owner) {
             throw InvalidAttributeException()
         }
 

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -113,7 +113,7 @@ abstract class BaseRemoteDescriptor(
 
     final override suspend fun read(): ByteArray {
         // Check whether the descriptor wasn't invalidated.
-        require(owner != null) {
+        requireNotNull(owner) {
             throw InvalidAttributeException()
         }
 
@@ -157,7 +157,7 @@ abstract class BaseRemoteDescriptor(
 
     final override suspend fun write(data: ByteArray) {
         // Check whether the descriptor wasn't invalidated.
-        require(owner != null) {
+        requireNotNull(owner) {
             throw InvalidAttributeException()
         }
 

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -406,7 +406,17 @@ class ScannerViewModel @Inject constructor(
                             // notifications or indications.
                             val expectError = !remoteCharacteristic.isSubscribable()
                             try {
-                                remoteCharacteristic.subscribe()
+                                remoteCharacteristic
+                                    // Note, that subscriber() method is no longer suspending.
+                                    // Notifications are enabled in onSubscription of the StateFlow.
+                                    // To get a callback when they are actually enabled, use the
+                                    // onSubscription parameter in subscribe().
+                                    .subscribe(
+                                        // This is called when the notifications were enabled.
+                                        onSubscription = {
+                                            Timber.i("($ce) Notifications for $uuid are now ${if (isNotifying) "enabled" else "disabled"}")
+                                        }
+                                    )
                                     .onStart {
                                         // This is called before the notifications are enabled.
                                         Timber.w("($ce) Subscribing to ${remoteCharacteristic.uuid}...")
@@ -429,8 +439,6 @@ class ScannerViewModel @Inject constructor(
                                         Timber.d("($ce) Stopped observing updates from ${remoteCharacteristic.uuid}")
                                     }
                                     .launchIn(scope)
-                                // remoteCharacteristic.setNotifying(true)
-                                Timber.i("($ce) Notifications for ${remoteCharacteristic.uuid} are now ${if (remoteCharacteristic.isNotifying) "enabled" else "disabled"}")
                             } catch (e: Exception) {
                                 if (!expectError) {
                                     Timber.e("($ce) Failed to subscribe to ${remoteCharacteristic.uuid}: ${e.message}")

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -467,7 +467,7 @@ class ScannerViewModel @Inject constructor(
             serviceUuid = LedButtonProfile.SERVICE_UUID,
             required = required,
         ) { lbs ->
-            val state = LedButtonServiceImpl(lbs, scope)
+            val state = LedButtonServiceImpl(lbs, this)
             Timber.i("LBS: LED Button Service found")
             block(state)
         }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
@@ -54,7 +54,6 @@ import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import timber.log.Timber
-import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
 
 /**
@@ -122,28 +121,39 @@ class LedButtonServiceImpl(
 
                     // Update the local state.
                     flow.update { isOn }
+                } catch (_: InvalidAttributeException) {
+                    // This exception is thrown when the device disconnects, or invalidates services.
+                    Timber.w("Services invalidated before reading the LED characteristic")
                 } catch (e: OperationFailedException) {
                     // In some implementations the LED characteristic is not readable.
                     Timber.w("Reading LED characteristic failed: ${e.message}")
+                } catch (e: BluetoothException) {
+                    // Other errors.
+                    Timber.e("Reading LED characteristic failed: ${e.message}")
                 }
 
                 // Whenever the value changes, write the value to the characteristic.
-                flow.collect { value ->
-                    try {
-                        val command = byteArrayOf(if (value) 1 else 0)
-                        ledCharacteristic.write(command)
-                    } catch (_: InvalidAttributeException) {
-                        // This exception is thrown when the device disconnects, or invalidates services.
-                        Timber.w("Services invalidated before writing to LED characteristic")
-                    } catch (e: OperationFailedException) {
-                        // This exception is thrown when the device disconnects, but the client
-                        // doesn't know about it before writing to the characteristic.
-                        // This usually indicates error 133.
-                        Timber.w("Writing to LED characteristic failed: ${e.message}")
-                    } catch (e: BluetoothException) {
-                        // Other errors.
-                        Timber.e("Writing to LED characteristic failed: ${e.message}")
+                try {
+                    flow.collect { value ->
+                        try {
+                            val command = byteArrayOf(if (value) 1 else 0)
+                            ledCharacteristic.write(command)
+                        } catch (_: InvalidAttributeException) {
+                            // This exception is thrown when the device disconnects, or invalidates services.
+                            Timber.w("Services invalidated before writing to LED characteristic")
+                        } catch (e: OperationFailedException) {
+                            // This exception is thrown when the device disconnects, but the client
+                            // doesn't know about it before writing to the characteristic.
+                            // This usually indicates error 133.
+                            Timber.w("Writing to LED characteristic failed: ${e.message}")
+                        } catch (e: BluetoothException) {
+                            // Other errors.
+                            Timber.e("Writing to LED characteristic failed: ${e.message}")
+                        }
                     }
+                } catch (e: Exception) {
+                    Timber.d("Stopped observing LED events")
+                    throw e
                 }
             }
         }
@@ -158,14 +168,25 @@ class LedButtonServiceImpl(
 
                     // Update the local state.
                     flow.update { pressed }
+                } catch (_: InvalidAttributeException) {
+                    // This exception is thrown when the device disconnects, or invalidates services.
+                    Timber.w("Services invalidated before reading the Button characteristic")
                 } catch (e: OperationFailedException) {
                     // In some implementations the Button characteristic is not readable.
                     Timber.w("Reading button characteristic failed: ${e.message}")
+                } catch (e: BluetoothException) {
+                    // Other errors.
+                    Timber.e("Reading button characteristic failed: ${e.message}")
                 }
 
                 // By having a local mutable flow we call subscribe() only once.
-                buttonCharacteristic.subscribe()
-                    .collect { flow.emit(it.state) }
+                try {
+                    buttonCharacteristic.subscribe()
+                        .collect { flow.emit(it.state) }
+                } catch (e: Exception) {
+                    Timber.d("Stopped observing button events")
+                    throw e
+                }
             }
         }
 


### PR DESCRIPTION
Before, it was incorrectly assume that a change of `services()` flow to `Unknown` is only caused by a disconnection.
However, a device may simply invalidate services from either side.
The previous implementation was cancelling the profile on disconnection, which was also a bug. `profile(..)`, just like `services(...)` should outlive the connection and emit events on reconnection.

This PR fixes all those issues and adds improved error handling and logs in the sample app.

Another but fixed in 4e5d68ffc473a7544f3158dbc831f7f050c62a2d was also fixed.