### PR TITLE
[Improvement] Catch mock validation errors

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -184,6 +184,12 @@ abstract class BaseRemoteCharacteristic(
                     } catch (e: InvalidAttributeException) {
                         // Thrown when the services have been invalidated.
                         throw e
+                    } catch (e: BluetoothException) {
+                        throw e
+                    } catch (_: IllegalStateException) {
+                        // Thrown when mock implementation checks for connection parameters.
+                        // If that fails, the attribute was invalidated.
+                        throw InvalidAttributeException()
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.
                         throw BluetoothException(e)
@@ -232,6 +238,12 @@ abstract class BaseRemoteCharacteristic(
                     } catch (e: InvalidAttributeException) {
                         // Thrown when the services have been invalidated.
                         throw e
+                    } catch (e: BluetoothException) {
+                        throw e
+                    } catch (_: IllegalStateException) {
+                        // Thrown when mock implementation checks for connection parameters.
+                        // If that fails, the attribute was invalidated.
+                        throw InvalidAttributeException()
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.
                         throw BluetoothException(e)

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -136,6 +136,12 @@ abstract class BaseRemoteDescriptor(
                     } catch (e: InvalidAttributeException) {
                         // Thrown when the services have been invalidated.
                         throw e
+                    } catch (e: BluetoothException) {
+                        throw e
+                    } catch (_: IllegalStateException) {
+                        // Thrown when mock implementation checks for connection parameters.
+                        // If that fails, the attribute was invalidated.
+                        throw InvalidAttributeException()
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.
                         throw BluetoothException(e)
@@ -183,6 +189,12 @@ abstract class BaseRemoteDescriptor(
                     } catch (e: InvalidAttributeException) {
                         // Thrown when the services have been invalidated.
                         throw e
+                    } catch (e: BluetoothException) {
+                        throw e
+                    } catch (_: IllegalStateException) {
+                        // Thrown when mock implementation checks for connection parameters.
+                        // If that fails, the attribute was invalidated.
+                        throw InvalidAttributeException()
                     } catch (e: Exception) {
                         // This is any other exception, i.e. SecurityException, etc.
                         throw BluetoothException(e)


### PR DESCRIPTION
This PR adds handling exceptions thrown by `check...` methods in the mock implementations of characteristic and descriptors. Before, they were wrapped in a `BluetoothException`. With this change, they are returned as `InvalidAttributeException`, as this is the actual root cause of the validation failure - when the device gets disconnected or the service gets invalidated.

As `BluetoothException` is also a `IllegalStateException` we need to catch it before and rethrow.