### PR TITLE
[Bugfix] Encoding UUID fixed

### DIFF
--- a/core-mock/src/main/java/no/nordicsemi/kotlin/ble/core/mock/AdvertisingDataDefinition.kt
+++ b/core-mock/src/main/java/no/nordicsemi/kotlin/ble/core/mock/AdvertisingDataDefinition.kt
@@ -331,7 +331,7 @@ class AdvertisingDataDefinition(
                 when {
                     uuid.is16BitUuid -> uuids16bit += uuid.toShortByteArray()
                     uuid.is32BitUuid -> uuids32bit += uuid.toShortByteArray()
-                    else -> uuids128bit += uuid.toByteArray()
+                    else -> uuids128bit += uuid.toByteArray().reversedArray()
                 }
             }
             return byteArrayOf(
@@ -350,7 +350,7 @@ class AdvertisingDataDefinition(
                 when {
                     uuid.is16BitUuid -> uuids16bit += uuid.toShortByteArray()
                     uuid.is32BitUuid -> uuids32bit += uuid.toShortByteArray()
-                    else -> uuids128bit += uuid.toByteArray()
+                    else -> uuids128bit += uuid.toByteArray().reversedArray()
                 }
             }
             return byteArrayOf(

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/util/BluetoothUuid.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/util/BluetoothUuid.kt
@@ -73,7 +73,7 @@ val Uuid.Companion.baseUuid: Uuid
      * What is "-0x7FFFFF7FA064CB05", you ask?
      *
      * Due to the fact, that the least significant part of the Base Bluetooth UUID
-     * (0x800000805f9b34fb) is outside of the range of Long, the value cannot be
+     * (0x800000805f9b34fb) is outside the range of Long, the value cannot be
      * simply written as UUID(0x0000000000001000, 0x800000805f9B34FB).
      * Instead, we take a 2's complement of the least significant part and invert the sign.
      */
@@ -157,7 +157,7 @@ fun Uuid.toShortByteArray(): ByteArray {
     return when {
         is16BitUuid -> bytes.sliceArray(2..3).reversedArray()
         is32BitUuid -> bytes.sliceArray(0..3).reversedArray()
-        else -> bytes
+        else -> bytes.reversedArray()
     }
 }
 
@@ -222,7 +222,10 @@ fun Uuid.Companion.fromBytes(uuidBytes: ByteArray, offset: Int, length: Int): Uu
             (uuidBytes[offset + 3].toInt() and 0xFF shl 24)
         return fromShortUuid(uuidVal)
     }
-    return fromLongs(uuidBytes.toLong(startIndex = offset + 8), uuidBytes.toLong(startIndex = offset))
+    return fromLongs(
+        uuidBytes.toLong(startIndex = offset + 8),
+        uuidBytes.toLong(startIndex = offset)
+    )
 }
 
 private fun ByteArray.toLong(startIndex: Int): Long {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -39,6 +39,7 @@ android {
     defaultConfig {
         applicationId = "no.nordicsemi.kotlin.ble.android.sample"
     }
+    @Suppress("UnstableApiUsage")
     androidResources {
         localeFilters += listOf("en")
     }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -117,6 +117,7 @@ class ScannerViewModel @Inject constructor(
 //                    ManufacturerData(0x0059)
 //                    ServiceUuid(Uuid.fromShortUuid(0x1809))
 //                }
+//                ServiceUuid(Uuid.parse("00001523-1212-EFDE-1523-785FEABCD123"))
                 Any {
                     Name("Pixel 5")
                     Name("Pixel 7")


### PR DESCRIPTION
When setting up a mock device, the UUIDs were encoded using Big Endian instead of Little Endian.