### PR TITLE
[Improvement] Profile disconnection change

### DIFF
--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpecEventHandler.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpecEventHandler.kt
@@ -35,8 +35,8 @@ import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.mock.internal.MockRemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.mock.internal.MockRemoteDescriptor
 import no.nordicsemi.kotlin.ble.core.OperationStatus
-import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import no.nordicsemi.kotlin.ble.core.Phy
+import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -577,21 +577,27 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * ## Services
      *
-     * As this is using [services] under the hood, it is safe and recommended to call this method
+     * As `profile` is using [services] under the hood, it is safe and recommended to call this method
      * before connecting the peripheral.
      *
-     * The [block] will be called every time the service is discovered,
+     * The [block] will be called every time the services are discovered,
      * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
-     * gets invalidated and rediscovered). To stop, cancel the scope in which the [block] is
-     * running, or use [profile] method with a custom scope.
+     * gets invalidated and rediscovered). To stop observing services cancel the job in which this
+     * method is called, or use the `profile` method with custom scope.
+     *
+     * If multiple services share the same [serviceUuid], only the first one is passed to `block`.
      *
      * ## Validation
      *
-     * If `block` throws [IllegalArgumentException] during service validation, and the profile
-     * was marked as [required], the connection will be terminated with reason
+     * If the profile was marked as [required] and the service is not found,
+     * or the `block` throws [IllegalArgumentException] during service validation, the connection
+     * will be terminated with reason
      * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
      *
-     * If multiple services share the same [serviceUuid], only the first one is passed to `block`.
+     * ## Block completion
+     *
+     * The device will NOT be disconnected when the [block] ends, unless the situation described
+     * in the Validation section.
      *
      * ## Example
      *
@@ -662,21 +668,26 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * ## Services
      *
-     * As this is using [services] under the hood, it is safe and recommended to call this method
+     * As `profile` is using [services] under the hood, it is safe and recommended to call this method
      * before connecting the peripheral.
      *
-     * The [block] will be called every time the service is discovered,
+     * The [block] will be called every time the services are discovered,
      * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
-     * gets invalidated and rediscovered). To stop, cancel the scope in which the [block] is
-     * running, or use [profile] method with a custom scope.
+     * gets invalidated and rediscovered). To stop observing services cancel the [scope].
+     *
+     * If multiple services share the same [serviceUuid], only the first one is passed to `block`.
      *
      * ## Validation
      *
-     * If `block` throws [IllegalArgumentException] during service validation, and the profile
-     * was marked as [required], the connection will be terminated with reason
+     * If the profile was marked as [required] and the service is not found,
+     * or the `block` throws [IllegalArgumentException] during service validation, the connection
+     * will be terminated with reason
      * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
      *
-     * If multiple services share the same [serviceUuid], only the first one is passed to `block`.
+     * ## Block completion
+     *
+     * The device will NOT be disconnected when the [block] ends, unless the situation described
+     * in the Validation section.
      *
      * ## Example
      *
@@ -789,19 +800,25 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * ## Services
      *
-     * As this is using [services] under the hood, it is safe and recommended to call this method
+     * As `profile` is using [services] under the hood, it is safe and recommended to call this method
      * before connecting the peripheral.
      *
-     * The [block] will be called every time the service is discovered,
+     * The [block] will be called every time the services are discovered,
      * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
-     * gets invalidated and rediscovered). To stop, cancel the scope in which the [block] is
-     * running, or use [profile] method with a custom scope.
+     * gets invalidated and rediscovered). To stop observing services cancel the job in this this
+     * method is called, or use `profile` method with custom scope.
      *
      * ## Validation
      *
-     * If `block` throws [IllegalArgumentException] during service validation, and the profile
-     * was marked as [required], the connection will be terminated with reason
+     * If the profile was marked as [required] and at least one of the required services is not found,
+     * or the `block` throws [IllegalArgumentException] during service validation, the connection
+     * will be terminated with reason
      * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     *
+     * ## Block completion
+     *
+     * The device will NOT be disconnected when the [block] ends, unless the situation described
+     * in the Validation section.
      *
      * ## Example
      *
@@ -880,26 +897,30 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * of the same service were discovered.
      *
      * The provided [block] is launched on a child coroutine in the given [scope] when all matching
-     * [RemoteService]s are emitted by the [services] flow. The launched job is canceled when
+     * [RemoteService]s are emitted by the [services] flow. The coroutine is canceled when
      * the peripheral disconnects (the cancellation cause is [PeripheralNotConnectedException])
-     * or when the job completes. When the `block` finishes (normally or exceptionally) the
-     * peripheral will be disconnected (with the reason [Success][ConnectionState.Disconnected.Reason.Success]).
+     * or service are invalidated (cause is [InvalidAttributeException]).
      *
      * ## Services
      *
-     * As this is using [services] under the hood, it is safe and recommended to call this method
+     * As `profile` is using [services] under the hood, it is safe and recommended to call this method
      * before connecting the peripheral.
      *
-     * The [block] will be called every time the service is discovered,
+     * The [block] will be called every time the services are discovered,
      * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
-     * gets invalidated and rediscovered). To stop, cancel the scope in which the [block] is
-     * running, or use [profile] method with a custom scope.
+     * gets invalidated and rediscovered). To stop observing services cancel the [scope].
      *
      * ## Validation
      *
-     * If `block` throws [IllegalArgumentException] during service validation, and the profile
-     * was marked as [required], the connection will be terminated with reason
+     * If the profile was marked as [required] and at least one of the required services is not found,
+     * or the `block` throws [IllegalArgumentException] during service validation, the connection
+     * will be terminated with reason
      * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     *
+     * ## Block completion
+     *
+     * The device will NOT be disconnected when the [block] ends, unless the situation described
+     * in the Validation section.
      *
      * ## Example
      *
@@ -1037,7 +1058,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                             userJob = scope.launch {
                                 try {
                                     block(state.services)
-                                    disconnect()
                                 } catch (e: Exception) {
                                     when (e) {
                                         // Rethrow cancellation exceptions, without any action.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -741,6 +741,8 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *                  .onEach {
      *                     cp.write(HeartRateControlPoint.RESET)
      *                  }
+     *                  // Note, that the collection is launched in the profile scope,
+     *                  // not the outer scope.
      *                  .launchIn(this)
      *          }
      *       }
@@ -751,7 +753,15 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      *    // 3. Await the scope cancellation. The scope will be canceled when the device disconnects,
      *    //    or the scope in which this method is called is canceled.
-     *    awaitCancellation()
+     *    try {
+     *        block(ledButtonService)
+     *    } catch (e: CancellationException) {
+     *        // Disconnect on scope cancellation, unless it's just service invalidation.
+     *        if (e.cause !is InvalidAttributeException) {
+     *            peripheral.disconnect()
+     *        }
+     *        throw e
+     *    }
      * }
      * ```
      *
@@ -978,6 +988,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *    linkLossAlertLevel?.write(ProximityProfile.ALERT_HIGH)
      *
      *    // Set up immediate alert.
+     *    // Note, that the collection is launched in the profile scope, not the outer scope.
      *    if (optionalServicesSupported) {
      *       buttonState
      *          .onEach {
@@ -990,7 +1001,13 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      *    // 3. Await the scope cancellation. The scope will be canceled when the device disconnects,
      *    //    or the scope in which this method is called is canceled.
-     *    awaitCancellation()
+     *    try {
+     *       awaitCancellation()
+     *    } finally {
+     *       // In this case, we want to disconnect here.
+     *       // It won't disconnect on its own.
+     *       peripheral.disconnect()
+     *    }
      * }
      * ```
      *


### PR DESCRIPTION
In the `Peripheral` class there's a `profile(...)` method, which registers service(s) observers. 
Before this PR, when the user block given to this method finished, the peripheral was disconnected.
However, the user block could have been cancelled due to several reasons, including Service Change indication (invalidating attribute cache). In that case, the disconnection wasn't intended.

For simplification, this PR removes the auto-disconnection from `profile` in case the user block was executed.
Should you want to close the connection, call `disconnect()` or use:
```kotlin
peripheral.profile(YyService,uuid) { service -> // this = user scope
   try {
      // Perform required Bluetooth LE operations...
      var myChar: RemoteCharacteristic = service.characteristics
         .firstOrNull { it.uuid == MyService.MyChar.uuid }
      requireNotNull(myChar)
      // [...]
   } catch (e: CancellationException) {
      // Disconnect on scope cancellation, unless it's just service invalidation.
      if (e.cause !is InvalidAttributeException) {
         peripheral.disconnect()
      }
      throw e
   }
}
```