### PR TITLE
[Feature] Automatic subscription for Service Changed indications

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -38,6 +38,7 @@ import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattService
+import android.os.Build
 import androidx.annotation.Keep
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -79,12 +80,21 @@ internal class NativeGattCallback: BluetoothGattCallback() {
      */
     var disconnectReason: ConnectionState.Disconnected.Reason? = null
 
+    /**
+     * A flag set when the service discovery was complete.
+     *
+     * This is only used on Android 8-11 which do not have `onServiceChanged` callback, but
+     * do report decreased connection interval during re-discovery.
+     */
+    private var isServiceDiscoveryComplete: Boolean = false
+
     // Handling connection state updates
 
     // TODO Remove all debug logs
 
     override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
         logger.debug("onConnectionStateChange: status=$status, newState=$newState")
+        isServiceDiscoveryComplete = false
         // Pixel 4 with Android 12 does return status 0 when link is lost to a device.
         // Newer versions (Pixel 7 with Android 16) report status 8 (timeout) in the same case.
         val betterStatus = if (
@@ -97,6 +107,7 @@ internal class NativeGattCallback: BluetoothGattCallback() {
 
     override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
         logger.debug("onServicesDiscovered: status=$status")
+        isServiceDiscoveryComplete = true
         if (status != BluetoothGatt.GATT_SUCCESS) {
             logger.warn("Services discovery failed with status $status")
             _events.tryEmit(ServiceDiscoveryFailed(RemoteServices.Failed.Reason.Unknown(status)))
@@ -222,9 +233,13 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         _events.tryEmit(PhyChanged(phyInUse))
     }
 
+    // Note:
+    // The base method is hidden in BluetoothGattCallback using @hide.
+    // It was added in Android 8 (Oreo) and it is possible to override it, but due to its hidden
+    // nature, it cannot use `override`.
     @Suppress("UNUSED_PARAMETER")
     @Keep
-    fun onConnectionUpdated(gatt: BluetoothGatt, interval: Int, latency: Int, timeout: Int, status: Int) {
+    /* override */ fun onConnectionUpdated(gatt: BluetoothGatt, interval: Int, latency: Int, timeout: Int, status: Int) {
         if (status != BluetoothGatt.GATT_SUCCESS) {
             logger.warn("Connection update failed with status $status")
             // no return, event must be emitted
@@ -232,6 +247,14 @@ internal class NativeGattCallback: BluetoothGattCallback() {
         val newParameters = ConnectionParameters.Specified(interval, latency, timeout)
         logger.debug("onConnectionUpdated: {}", newParameters)
         _events.tryEmit(ConnectionParametersChanged(newParameters))
+
+        // Android starts reporting Service Changed event starting from API 31 (S).
+        // However, since API 26 it was possible to detect it by listening to connection
+        // parameters update, which decreased the interval to 7.5 ms during service discovery.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+            isServiceDiscoveryComplete && interval == 6 /* 7.5 ms */ ) {
+            onServiceChanged(gatt)
+        }
     }
 
     /**

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -573,6 +573,9 @@ class PeripheralSpec<ID: Any> private constructor(
 
                 // If any client is still connected, emit the event.
                 if (isConnected) {
+                    // TODO Pre-Oreo Android versions do not report Service Changed events.
+                    // TODO Android 6+ (until 15?) report 7.5ms interval during service discovery.
+                    // On Android 16 the 7.5 ms interval is not reported? No longer a thing?
                     _events.emit(ServicesChanged)
                 }
             }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -418,11 +418,30 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         .firstOrNull { it.uuid == Service.GENERIC_ATTRIBUTE_UUID }
                         ?.characteristics
                         ?.firstOrNull { it.uuid == Characteristic.SERVICE_CHANGED }
-                        ?.apply {
-                            logger.trace("Enabling Service Changed indications")
-                            setNotifying(true)
-                            logger.info("Service Changed indications enabled")
+                        ?.also { logger.trace("Enabling Service Changed indications") }
+                        ?.subscribe { logger.info("Service Changed indications enabled") }
+                        ?.onEach {
+                            // The Service Changed indication is consumed by the system.
+                            //
+                            // * Android versions since Android 12 will notify the app using
+                            //   `onServiceChanged` callback.
+                            // * Android versions 8-11 refresh the cache, but do not notify the app.
+                            //   However, during service discovery they switch to connection
+                            //   interval 7.5 ms (6 units), which only happens during discovery.
+                            //   This library detects it, and reports `ServicesChanged` event
+                            //   (see NativeGattCallback).
+                            // * Android versions prior to 8 also refresh services, but
+                            //   they don't have a hidden `onConnectionUpdated` method, so it is
+                            //   not possible to detect when the services get invalidated.
+                            //
+                            // None of the phones we tested (Android 6 - 16) indicated anything
+                            // on Service Change characteristic.
+                            // However, perhaps older Android versions do not handle SC indication
+                            // internally, and will report it to the app, so let's use it to
+                            // indicate service change.
+                            handle(ServicesChanged)
                         }
+                        ?.launchIn(scope)
                 } catch (e: Exception) {
                     logger.warn("Enabling Service Changed indications failed: ${e.message}")
                 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -61,10 +61,12 @@ import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.PeripheralNotConnectedException
 import no.nordicsemi.kotlin.ble.client.internal.OperationMutex
+import no.nordicsemi.kotlin.ble.core.Characteristic
 import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.Peer
 import no.nordicsemi.kotlin.ble.core.Phy
+import no.nordicsemi.kotlin.ble.core.Service
 import no.nordicsemi.kotlin.ble.core.WriteType
 import org.slf4j.LoggerFactory
 import kotlin.coroutines.cancellation.CancellationException
@@ -407,12 +409,24 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                     logger.warn(e.message)
                 }
                 logger.info("Services discovered")
-                _services.update {
-                    // Assign the owner to each service, making them valid.
-                    RemoteServices.Discovered(
-                    event.services.onEach { it.owner = this }
-                    )
+                // Assign the owner to each service, making them valid.
+                val services = event.services.onEach { it.owner = this }
+                // Search for Service Changed characteristic and enable CCCD.
+                // This characteristic notifies about service changes.
+                try {
+                    services
+                        .firstOrNull { it.uuid == Service.GENERIC_ATTRIBUTE_UUID }
+                        ?.characteristics
+                        ?.firstOrNull { it.uuid == Characteristic.SERVICE_CHANGED }
+                        ?.apply {
+                            logger.trace("Enabling Service Changed indications")
+                            setNotifying(true)
+                            logger.info("Service Changed indications enabled")
+                        }
+                } catch (e: Exception) {
+                    logger.warn("Enabling Service Changed indications failed: ${e.message}")
                 }
+                _services.update { RemoteServices.Discovered(services) }
             }
 
             is ServiceDiscoveryFailed -> {

--- a/environment-android-compose/src/main/java/no/nordicsemi/kotlin/ble/environment/android/compose/LocalEnvironment.kt
+++ b/environment-android-compose/src/main/java/no/nordicsemi/kotlin/ble/environment/android/compose/LocalEnvironment.kt
@@ -116,7 +116,7 @@ object LocalEnvironmentOwner {
         val isMock = try { environment is MockAndroidEnvironment }
         catch (e: NoClassDefFoundError) { false }
 
-        if (isMock && environment is MockAndroidEnvironment) {
+        if (isMock && (environment is MockAndroidEnvironment)) {
             // Modify the LocalActivityResultRegistryOwner only in the mock environment.
             val realOwner = LocalActivityResultRegistryOwner.current
             val registry: ActivityResultRegistry = remember {
@@ -126,7 +126,7 @@ object LocalEnvironmentOwner {
                         BLUETOOTH_CONNECT,
                         BLUETOOTH_SCAN,
                         BLUETOOTH_ADVERTISE,
-                        ACCESS_FINE_LOCATION
+                        ACCESS_FINE_LOCATION,
                     )
 
                     override fun <I, O> onLaunch(
@@ -195,7 +195,8 @@ object LocalEnvironmentOwner {
                                     is ActivityResultContracts.RequestMultiplePermissions ->
                                         dispatchResult(
                                             requestCode,
-                                            permissions.associateWith { it.isGranted() })
+                                            permissions.associateWith { it.isGranted() },
+                                        )
                                 }
                                 return
                             }

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
@@ -33,36 +33,22 @@ package no.nordicsemi.kotlin.ble.android.sample.scanner
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import no.nordicsemi.kotlin.ble.android.sample.common.DeviceList
-import no.nordicsemi.kotlin.ble.client.android.Peripheral
-import no.nordicsemi.kotlin.ble.client.android.preview.PreviewPeripheral
-import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.android.AndroidEnvironment
 import no.nordicsemi.kotlin.ble.environment.android.compose.LocalEnvironmentOwner
 


### PR DESCRIPTION
This PR adds automatic subscription for Service Change indications. This will happen each time after services are discovered.

An indication sent by this characteristic causes the system to invalidate services and triggers new service discovery.

TODO:
- [ ] Should this be moved to `android.Peripheral`? This is a NOOP on iOS, where SC is not exposed.
- [ ] Should we check if SC are already enabled?
- [ ] Should the log(s) be removed?
- [ ] On Android pre-31 where [onServiceChanged](https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback#onServiceChanged(android.bluetooth.BluetoothGatt)) is not present, we should subscribe and listen to changes and trigger invalidating cache manually.