### PR TITLE
[Bugfix] Aborting reconnection when required service was not found

### DIFF
--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/ConnectionState.kt
@@ -150,9 +150,12 @@ sealed class ConnectionState {
          * A quick check whether the disconnection was initiated by the user.
          *
          * This returns `false` in the initial state, that is before the connection attempt was started.
+         *
+         * `True` is returned if `disconnect()` method was called, which happens
+         * with the `reason` is `Success`, `Cancelled` or `RequiredServiceNotFound`.
          */
         val isUserInitiated: Boolean
-            get() = reason is Success || reason is Cancelled
+            get() = reason is Success || reason is Cancelled || reason is Reason.RequiredServiceNotFound
     }
 
     /** Whether the connection is open. */


### PR DESCRIPTION
This PR fixes a bug causing the state to switch from `Disconnecting` to `Connection` in case the required service was not found.

1. Connect using `AutoConnect` and `profile` method called with some service UUID.
2. This service is not found in discovered services.
3. The library calls `disconnect()` reporting `RequiredServiceNotFound` as disconnection reason.
4. Bug: the state changes to `Connecting` as if auto-reconnection was ongoing.
   * Remember, that `disconnect()` cancels auto-connection.

With this fix the state will be reported correctly as `Disconnected(reason = RequiredServiceNotFound)`.