### PR TITLE
[Bugfix] Requesting Location permission in sample app

### DIFF
--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerScreen.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.kotlin.ble.android.sample.scanner
 
+import android.Manifest.permission.ACCESS_FINE_LOCATION
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -69,14 +70,26 @@ fun ScannerScreen() {
     ) {
         Text(text = "Bluetooth state: $state")
 
-        // Scanning requires BLUETOOTH_SCAN permission, but
-        // reading device name or bond state requires BLUETOOTH_CONNECT permission.
-        val permissions = arrayOf(
-            AndroidEnvironment.Permission.BLUETOOTH_SCAN,
-            AndroidEnvironment.Permission.BLUETOOTH_CONNECT,
-        )
+        var permissions = arrayOf<String>()
+        if (environment.isLocationRequiredForScanning) {
+            // Location permission is required to scan for Bluetooth LE devices on Android 12 and below,
+            // or when 'neverForLocation' is set to 'false' in the manifest.
+            permissions += ACCESS_FINE_LOCATION
+        }
+        if (environment.requiresBluetoothRuntimePermissions) {
+             // Bluetooth permissions are required to scan for Bluetooth LE devices on Android 12 and above.
+             permissions += AndroidEnvironment.Permission.BLUETOOTH_SCAN
+             permissions += AndroidEnvironment.Permission.BLUETOOTH_CONNECT
+        }
         var permissionGranted by remember {
-            mutableStateOf(environment.isBluetoothScanPermissionGranted && environment.isBluetoothConnectPermissionGranted)
+            val bluetoothPermissions =
+                environment.requiresBluetoothRuntimePermissions &&
+                environment.isBluetoothScanPermissionGranted &&
+                environment.isBluetoothConnectPermissionGranted
+            val locationPermission =
+                environment.isLocationRequiredForScanning &&
+                environment.isLocationPermissionGranted
+            mutableStateOf(bluetoothPermissions || locationPermission)
         }
         val launcher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.RequestMultiplePermissions(),
@@ -84,7 +97,14 @@ fun ScannerScreen() {
                 // This may not work.
                 // permissionGranted = it.values.all { true }
                 // Use this instead:
-                permissionGranted = environment.isBluetoothScanPermissionGranted && environment.isBluetoothConnectPermissionGranted
+                val bluetoothPermissions =
+                    environment.requiresBluetoothRuntimePermissions &&
+                            environment.isBluetoothScanPermissionGranted &&
+                            environment.isBluetoothConnectPermissionGranted
+                val locationPermission =
+                    environment.isLocationRequiredForScanning &&
+                            environment.isLocationPermissionGranted
+                permissionGranted = bluetoothPermissions || locationPermission
             }
         )
 

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -65,7 +65,9 @@ import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.android.preview.PreviewPeripheral
 import no.nordicsemi.kotlin.ble.client.distinctByPeripheral
 import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
+import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.core.ConnectionState
+import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.PhyInUse
 import no.nordicsemi.kotlin.ble.core.WriteType
@@ -376,14 +378,16 @@ class ScannerViewModel @Inject constructor(
                     services.forEach { remoteService ->
                         Timber.i("($ce) Reading characteristics of ${remoteService.uuid}:")
                         remoteService.characteristics.forEach { remoteCharacteristic ->
+                            val expectError = !remoteCharacteristic.isReadable()
                             try {
                                 val value = remoteCharacteristic.read()
                                 Timber.i("- Value of ${remoteCharacteristic.uuid}: 0x${value.toHexString()}")
                             } catch (e: Exception) {
-                                Timber.e(
-                                    e,
-                                    "- Failed to read ${remoteCharacteristic.uuid}: ${e.message}"
-                                )
+                                if (expectError) {
+                                    Timber.w("- Value of ${remoteCharacteristic.uuid}: Read not permitted")
+                                } else {
+                                    Timber.e(e, "- Failed to read ${remoteCharacteristic.uuid}: ${e.message}")
+                                }
                             }
 
                             for (descriptor in remoteCharacteristic.descriptors) {
@@ -391,10 +395,12 @@ class ScannerViewModel @Inject constructor(
                                     val descValue = descriptor.read()
                                     Timber.i("   - Value of descriptor ${descriptor.uuid}: 0x${descValue.toHexString()}")
                                 } catch (e: Exception) {
-                                    Timber.e(
-                                        e,
-                                        "   - Failed to read descriptor ${descriptor.uuid}: ${e.message}"
-                                    )
+                                    if (e is OperationFailedException && e.reason == OperationStatus.ReadNotPermitted) {
+                                        // This is expected for Client Characteristic Configuration Descriptor of non-notifiable characteristics.
+                                        Timber.w("   - Value of descriptor ${descriptor.uuid}: Read not permitted")
+                                    } else {
+                                        Timber.e(e, "   - Failed to read descriptor ${descriptor.uuid}: ${e.message}")
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Before `BLUETOOTH_SCAN` and other `BLUETOOTH_*` permissions were added the Location Fine permission was required to scan for Bluetooth LE devices.

This PR adds this permission to the requested ones for native and mock environments.