### PR TITLE
Adding SPDX SBOM generation

### DIFF
--- a/advertiser-android-mock/build.gradle.kts
+++ b/advertiser-android-mock/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "advertiser-android-mock"
     POM_NAME = "Mock Android Advertiser Mocule"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing functionality for Bluetooth LE advertising on mock Android devices."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/advertiser-android/build.gradle.kts
+++ b/advertiser-android/build.gradle.kts
@@ -41,8 +41,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "advertiser-android"
     POM_NAME = "Android Advertiser Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing Android-specific functionality for Bluetooth LE advertising."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/advertiser-core-android/build.gradle.kts
+++ b/advertiser-core-android/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "advertiser-core-android"
     POM_NAME = "Core Android Advertiser Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing core functionality for Bluetooth LE advertising on Android devices."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/advertiser-core/build.gradle.kts
+++ b/advertiser-core/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "advertiser-core"
     POM_NAME = "Core Advertiser Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing core, platform-independent functionality for Bluetooth LE advertising."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/client-android-mock/build.gradle.kts
+++ b/client-android-mock/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "client-android-mock"
     POM_NAME = "Mock Bluetooth LE Client Module for Android"
     POM_DESCRIPTION = "A main module of Kotlin BLE Library providing Android-specific functionality for testing scanning, connecting and interacting with using Bluetooth LE peripherals."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/client-android/build.gradle.kts
+++ b/client-android/build.gradle.kts
@@ -41,8 +41,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "client-android"
     POM_NAME = "Bluetooth LE Client Module for Android"
     POM_DESCRIPTION = "A main module of Kotlin BLE Library providing Android-specific functionality for scanning, connecting and interacting with Bluetooth LE peripherals."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/client-core-android/build.gradle.kts
+++ b/client-core-android/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "client-core-android"
     POM_NAME = "Core Android Client Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing core Android-specific functionality for Bluetooth LE client operations."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/client-core-mock/build.gradle.kts
+++ b/client-core-mock/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "client-core-mock"
     POM_NAME = "Core Client Mock Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing core mock functionality for Bluetooth LE client operations."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/client-core/build.gradle.kts
+++ b/client-core/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "client-core"
     POM_NAME = "Core Client Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing core, platform-independent functionality for Bluetooth LE client operations."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/core-android/build.gradle.kts
+++ b/core-android/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "core-android"
     POM_NAME = "Core Android Module"
     POM_DESCRIPTION = "Set of common Android-related classes and utilities for the Kotlin BLE Library."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/core-mock/build.gradle.kts
+++ b/core-mock/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "core-mock"
     POM_NAME = "Core Mock Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing core mock functionality for Bluetooth LE operations."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -63,8 +63,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "core"
     POM_NAME = "Kotlin BLE Library Core Module"
     POM_DESCRIPTION = "Set of common classes and utilities for the Kotlin BLE Library."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/environment-android-compose/build.gradle.kts
+++ b/environment-android-compose/build.gradle.kts
@@ -41,8 +41,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "environment-android-compose"
     POM_NAME = "Utils for Compose"
     POM_DESCRIPTION = "Set of utilities for Jetpack Compose integration on Android."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/environment-android-mock/build.gradle.kts
+++ b/environment-android-mock/build.gradle.kts
@@ -40,8 +40,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "environment-android-mock"
     POM_NAME = "Mock Android Environment Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing a mock Android-specific environment implementation."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/environment-android/build.gradle.kts
+++ b/environment-android/build.gradle.kts
@@ -41,8 +41,8 @@ nordicPublishing {
     POM_ARTIFACT_ID = "environment-android"
     POM_NAME = "Native Android Environment Module"
     POM_DESCRIPTION = "A part of Kotlin BLE Library providing Android-specific environment implementation."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library"
+    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
+    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,7 @@ pluginManagement {
                 includeGroupAndSubgroups("com.gradle")
                 includeGroupAndSubgroups("no.nordicsemi")
                 includeGroupAndSubgroups("org.jetbrains")
+                includeGroupAndSubgroups("org.spdx")
             }
         }
         mavenCentral()
@@ -68,7 +69,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         // Use Nordic Gradle Version Catalog with common external libraries versions.
         create("libs") {
-            from("no.nordicsemi.gradle:version-catalog-min-sdk-21:3.0")
+            from("no.nordicsemi.gradle:version-catalog-min-sdk-21:3.1")
         }
         // Fixed versions for Nordic libraries.
         create("nordic") {


### PR DESCRIPTION
This PR updates the Nordi Gradle Plugins version to [3.1](https://github.com/nordicsemi/Nordic-Gradle-Plugins/releases/tag/3.1). This version generates a SPDX SBOM file in released maven artifacts.

The URLs were fixes, so the `documentNamespace` is correct.