### PR TITLE
Bugfix: Skip malformed Manufacturer Specific Data instead of crashing

### DIFF
--- a/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/AdvertisingData.kt
+++ b/client-core-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/AdvertisingData.kt
@@ -190,10 +190,14 @@ class AdvertisingData(
                     }
                 }
                 AdvertisingDataType.MANUFACTURER_SPECIFIC_DATA -> {
-                    val companyId = (raw[i].toInt() and 0xFF) or (raw[i + 1].toInt() and 0xFF shl 8)
-                    val data = raw.copyOfRange(i + 2, i + length)
-                    manufacturerData = (manufacturerData ?: mutableMapOf()).apply {
-                        put(companyId, data)
+                    // The structure must contain at least the 2-byte Company ID.
+                    // Shorter structures are malformed and are skipped.
+                    if (length >= 2) {
+                        val companyId = (raw[i].toInt() and 0xFF) or (raw[i + 1].toInt() and 0xFF shl 8)
+                        val data = raw.copyOfRange(i + 2, i + length)
+                        manufacturerData = (manufacturerData ?: mutableMapOf()).apply {
+                            put(companyId, data)
+                        }
                     }
                 }
                 AdvertisingDataType.PB_ADV -> {

--- a/client-core-android/src/test/java/no/nordicsemi/kotlin/ble/client/android/AdvertisingDataTest.kt
+++ b/client-core-android/src/test/java/no/nordicsemi/kotlin/ble/client/android/AdvertisingDataTest.kt
@@ -246,7 +246,8 @@ class AdvertisingDataTest {
         val parsedData = ad.manufacturerData
 
         Truth.assertThat(parsedData).isNotNull()
-        Truth.assertThat(parsedData).containsEntry(manufacturerData, manufacturerId)
+        Truth.assertThat(parsedData).containsKey(manufacturerId)
+        Truth.assertThat(parsedData[manufacturerId]).isEqualTo(manufacturerData)
     }
 
     @Test

--- a/core-mock/src/main/java/no/nordicsemi/kotlin/ble/core/mock/AdvertisingDataDefinition.kt
+++ b/core-mock/src/main/java/no/nordicsemi/kotlin/ble/core/mock/AdvertisingDataDefinition.kt
@@ -174,10 +174,14 @@ class AdvertisingDataDefinition(
                     }
                 }
                 AdvertisingDataType.MANUFACTURER_SPECIFIC_DATA -> {
-                    val companyId = (raw[i].toInt() and 0xFF) or (raw[i + 1].toInt() and 0xFF shl 8)
-                    val data = raw.copyOfRange(i + 2, i + length)
-                    manufacturerData = (manufacturerData ?: mutableMapOf()).apply {
-                        put(companyId, data)
+                    // The structure must contain at least the 2-byte Company ID.
+                    // Shorter structures are malformed and are skipped.
+                    if (length >= 2) {
+                        val companyId = (raw[i].toInt() and 0xFF) or (raw[i + 1].toInt() and 0xFF shl 8)
+                        val data = raw.copyOfRange(i + 2, i + length)
+                        manufacturerData = (manufacturerData ?: mutableMapOf()).apply {
+                            put(companyId, data)
+                        }
                     }
                 }
                 AdvertisingDataType.PB_ADV -> {


### PR DESCRIPTION
I came across 2 failing tests while going through the library which uncovered a minor bug in parsing advertising data so I figured I'd submit a fix. Below is a detailed explanation of the issue and fix. Thank you for this amazing library! :)

## Summary
A Manufacturer Specific Data AD structure shorter than its mandatory 2-byte Company ID
crashed the advertising-data parser. It is now skipped, like other malformed AD structures.

## Problem
Advertising data comes from remote, untrusted peripherals. A Manufacturer Specific Data
(`0xFF`) structure with fewer than 2 data octets threw during parsing —
`ArrayIndexOutOfBoundsException` at the end of a packet, otherwise `IllegalArgumentException`
from `copyOfRange` — breaking the whole scan result. One nonconformant advertiser in range
is enough to trigger it.

## Root cause
The branch read two Company-ID octets and sliced the rest without a length check:

```kotlin
val companyId = (raw[i].toInt() and 0xFF) or (raw[i + 1].toInt() and 0xFF shl 8)
val data = raw.copyOfRange(i + 2, i + length)
```

When `length < 2`, both reads go out of bounds.

## Fix
Guard the branch with `length >= 2`. Per the
[Bluetooth Core Specification Supplement, Part A §1.4.2](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v11/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html),
the first two octets *shall* contain the Company ID, so a shorter structure
is malformed. The parser already ensures `length` fits the buffer, so `>= 2` makes both ID
bytes safe. Company-ID-only structure (`length == 2`) stays valid.

The same parser is duplicated in `core-mock`'s `AdvertisingDataDefinition` and is fixed there too.

## Tests
- Corrected `test Manufacturer Specific Data`, whose assertion had the key/value reversed and
  compared `ByteArray` by reference, so it never validated the parse.
- `test malformed Manufacturer Data - too short` covers the crashing input and asserts the
  structure is skipped.
-  All tests in the repo pass now
