### PR TITLE
[Feature] Profile improvements

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -1156,6 +1156,260 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
     }
 
     /**
+     * Registers a profile implementation that runs when the specified GATT services are discovered.
+     *
+     * ## Overview
+     *
+     * Decouples the Bluetooth LE profile interface from application logic, allowing each
+     * device feature (profile) to run in its own coroutine.
+     *
+     * Multiple profiles can be added by calling this method once for each service,
+     * i.e. Battery Profile and Heart Rate Profile.
+     *
+     * This method suspends only to get the current coroutine scope using [currentCoroutineContext].
+     * The profile is executed in a child coroutine.
+     *
+     * ## Services
+     *
+     * As `profile` is using [services] under the hood, it is safe and recommended to call this method
+     * before connecting the peripheral.
+     *
+     * The profile will be executed every time the services are discovered,
+     * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
+     * gets invalidated and rediscovered). To stop observing services cancel the [scope].
+     *
+     * ## Validation
+     *
+     * If the profile was marked as [required] and at least one of the required services is not found,
+     * or the `block` throws [IllegalArgumentException] during service validation, the connection
+     * will be terminated with reason
+     * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     *
+     * #### Example
+     *
+     * ##### Profile definition
+     * ```kotlin
+     * /**
+     *  * API of the profile.
+     *  */
+     * interface LedButton {
+     *     /** The current button state on the DK. */
+     *     val buttonState: StateFlow<Boolean>
+     *     /** The LED state. */
+     *     val ledState: MutableStateFlow<Boolean>
+     * }
+     *
+     * class LedButtonProfile: Profile.Simple(
+     *     serviceUuid = SERVICE_UUID,
+     *     name = "LBS",
+     * ), LedButton {
+     *     companion object {
+     *         val SERVICE_UUID = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+     *         val BUTTON_CHARACTERISTIC_UUID = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
+     *         val LED_CHARACTERISTIC_UUID = Uuid.parse("00001525-1212-efde-1523-785feabcd123")
+     *     }
+     *
+     *     // GATT characteristics.
+     *     private lateinit var buttonCharacteristic: RemoteCharacteristic
+     *     private lateinit var ledCharacteristic: RemoteCharacteristic
+     *
+     *     // Public API.
+     *     private val _buttonState = MutableStateFlow(false)
+     *     override val buttonState: StateFlow<Boolean> = _buttonState.asStateFlow()
+     *     override val ledState: MutableStateFlow<Boolean> = MutableStateFlow(false)
+     *
+     *     // Implementation.
+     *     override fun prepare(service: RemoteService) {
+     *         // This should always pass.
+     *         require(service.uuid == SERVICE_UUID)
+     *
+     *         // Obtain characteristics from the service.
+     *         buttonCharacteristic = service.characteristics.first { it.uuid == BUTTON_CHARACTERISTIC_UUID }
+     *         ledCharacteristic = service.characteristics.first { it.uuid == LED_CHARACTERISTIC_UUID }
+     *
+     *         // Validate properties.
+     *         require(buttonCharacteristic.isSubscribable()) { "Button characteristic must be subscribable." }
+     *         require(ledCharacteristic.isWritable()) { "LED characteristic must be writable." }
+     *     }
+     *
+     *     override suspend fun CoroutineScope.initialize() {
+     *         // Subscribe to button characteristic.
+     *         buttonCharacteristic
+     *             .subscribe()
+     *             .map { value -> value.singleOrNull() == 1.toByte() }
+     *             .onEach { isPressed -> _buttonState.update { isPressed } }
+     *             .launchIn(this)
+     *
+     *         // Read current Button state.
+     *         try {
+     *             val currentState = buttonCharacteristic.read()
+     *             _buttonState.update { currentState.singleOrNull() == 1.toByte() }
+     *         } catch (e: OperationFailedException) {
+     *             println("Reading button characteristic failed: ${e.message}")
+     *         }
+     *
+     *         // Handle LED state updates.
+     *         ledState
+     *             .map { isOn -> byteArrayOf(if (isOn) 1 else 0) }
+     *             .onEach { value ->
+     *                 try {
+     *                     ledCharacteristic.write(value)
+     *                 } catch (e: OperationFailedException) {
+     *                     println("Writing LED characteristic failed: ${e.message}")
+     *                 }
+     *             }
+     *             .launchIn(this)
+     *     }
+     * }
+     * ```
+     * ##### Usage
+     * ```kotlin
+     * val api: LedButton = LedButtonProfile()
+     *    .also { peripheral.profile(it) }
+     * ```
+     *
+     * @param profile The profile implementation.
+     * @param required Whether support for this profile is required by the app.
+     */
+    suspend fun profile(profile: Profile, required: Boolean = true) = profile(
+        requiredServiceUuids = profile.requiredServiceUuids,
+        optionalServiceUuids = profile.optionalServiceUuids,
+        required = required,
+        name = profile.name,
+        block = {services ->
+            profile.execute(services, this)
+        }
+    )
+
+    /**
+     * Registers a profile implementation that runs when the specified GATT services are discovered.
+     *
+     * ## Overview
+     *
+     * Decouples the Bluetooth LE profile interface from application logic, allowing each
+     * device feature (profile) to run in its own coroutine.
+     *
+     * Multiple profiles can be added by calling this method once for each service,
+     * i.e. Battery Profile and Heart Rate Profile.
+     *
+     * This method suspends only to get the current coroutine scope using [currentCoroutineContext].
+     * The profile is executed in a child coroutine.
+     *
+     * ## Services
+     *
+     * As `profile` is using [services] under the hood, it is safe and recommended to call this method
+     * before connecting the peripheral.
+     *
+     * The profile will be executed every time the services are discovered,
+     * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
+     * gets invalidated and rediscovered). To stop observing services cancel the [scope].
+     *
+     * ## Validation
+     *
+     * If the profile was marked as [required] and at least one of the required services is not found,
+     * or the `block` throws [IllegalArgumentException] during service validation, the connection
+     * will be terminated with reason
+     * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     *
+     * #### Example
+     *
+     * ##### Profile definition
+     * ```kotlin
+     * /**
+     *  * API of the profile.
+     *  */
+     * interface LedButton {
+     *     /** The current button state on the DK. */
+     *     val buttonState: StateFlow<Boolean>
+     *     /** The LED state. */
+     *     val ledState: MutableStateFlow<Boolean>
+     * }
+     *
+     * class LedButtonProfile: Profile.Simple(
+     *     serviceUuid = SERVICE_UUID,
+     *     name = "LBS",
+     * ), LedButton {
+     *     companion object {
+     *         val SERVICE_UUID = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
+     *         val BUTTON_CHARACTERISTIC_UUID = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
+     *         val LED_CHARACTERISTIC_UUID = Uuid.parse("00001525-1212-efde-1523-785feabcd123")
+     *     }
+     *
+     *     // GATT characteristics.
+     *     private lateinit var buttonCharacteristic: RemoteCharacteristic
+     *     private lateinit var ledCharacteristic: RemoteCharacteristic
+     *
+     *     // Public API.
+     *     private val _buttonState = MutableStateFlow(false)
+     *     override val buttonState: StateFlow<Boolean> = _buttonState.asStateFlow()
+     *     override val ledState: MutableStateFlow<Boolean> = MutableStateFlow(false)
+     *
+     *     // Implementation.
+     *     override fun prepare(service: RemoteService) {
+     *         // This should always pass.
+     *         require(service.uuid == SERVICE_UUID)
+     *
+     *         // Obtain characteristics from the service.
+     *         buttonCharacteristic = service.characteristics.first { it.uuid == BUTTON_CHARACTERISTIC_UUID }
+     *         ledCharacteristic = service.characteristics.first { it.uuid == LED_CHARACTERISTIC_UUID }
+     *
+     *         // Validate properties.
+     *         require(buttonCharacteristic.isSubscribable()) { "Button characteristic must be subscribable." }
+     *         require(ledCharacteristic.isWritable()) { "LED characteristic must be writable." }
+     *     }
+     *
+     *     override suspend fun CoroutineScope.initialize() {
+     *         // Subscribe to button characteristic.
+     *         buttonCharacteristic
+     *             .subscribe()
+     *             .map { value -> value.singleOrNull() == 1.toByte() }
+     *             .onEach { isPressed -> _buttonState.update { isPressed } }
+     *             .launchIn(this)
+     *
+     *         // Read current Button state.
+     *         try {
+     *             val currentState = buttonCharacteristic.read()
+     *             _buttonState.update { currentState.singleOrNull() == 1.toByte() }
+     *         } catch (e: OperationFailedException) {
+     *             println("Reading button characteristic failed: ${e.message}")
+     *         }
+     *
+     *         // Handle LED state updates.
+     *         ledState
+     *             .map { isOn -> byteArrayOf(if (isOn) 1 else 0) }
+     *             .onEach { value ->
+     *                 try {
+     *                     ledCharacteristic.write(value)
+     *                 } catch (e: OperationFailedException) {
+     *                     println("Writing LED characteristic failed: ${e.message}")
+     *                 }
+     *             }
+     *             .launchIn(this)
+     *     }
+     * }
+     * ```
+     * ##### Usage
+     * ```kotlin
+     * val api: LedButton = LedButtonProfile()
+     *    .also { peripheral.profile(it) }
+     * ```
+     *
+     * @param scope The coroutine scope to launch the user block in.
+     * @param profile The profile implementation.
+     * @param required Whether support for this profile is required by the app.
+     */
+    fun profile(scope: CoroutineScope, profile: Profile, required: Boolean = true) = profile(
+        scope = scope,
+        requiredServiceUuids = profile.requiredServiceUuids,
+        optionalServiceUuids = profile.optionalServiceUuids,
+        required = required,
+        name = profile.name,
+        block = {services ->
+            profile.execute(services, this)
+        }
+    )
+
+    /**
      * Suspends until the peripheral is disconnected.
      *
      * @throws CancellationException if the current coroutine is canceled.
@@ -1194,7 +1448,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
         check (isConnected) {
             throw PeripheralNotConnectedException()
         }
-        return OperationMutex.withLock {
+        return OperationMutex.withLock(logger, "Read RSSI") {
             logger?.trace(Layer.LINK) { "Reading RSSI" }
             impl.events
                 .onSubscription {
@@ -1239,7 +1493,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * when disconnection was initiated by the user.
      */
     internal suspend fun disconnect(reason: ConnectionState.Disconnected.Reason) = withContext(NonCancellable) {
-        OperationMutex.withLock {
+        OperationMutex.withLock(logger, "Disconnect") {
             // Depending on the state...
             when (state.value) {
                 is ConnectionState.Disconnected -> {

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -1106,6 +1107,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                             userJob = scope.launch {
                                 try {
                                     block(state.services)
+                                    awaitCancellation()
                                 } catch (e: Exception) {
                                     when (e) {
                                         // Rethrow cancellation exceptions, without any action.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -790,18 +790,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *          // Update UI or something.
      *       }
      *       .launchIn(this)
-     *
-     *    // 3. Await the scope cancellation. The scope will be canceled when the device disconnects,
-     *    //    or the scope in which this method is called is canceled.
-     *    try {
-     *        block(ledButtonService)
-     *    } catch (e: CancellationException) {
-     *        // Disconnect on scope cancellation, unless it's just service invalidation.
-     *        if (e.cause !is InvalidAttributeException) {
-     *            peripheral.disconnect()
-     *        }
-     *        throw e
-     *    }
      * }
      * ```
      *
@@ -855,7 +843,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * The [block] will be called every time the services are discovered,
      * which may happen multiple times (e.g. when the peripheral reconnects, or when the service
-     * gets invalidated and rediscovered). To stop observing services cancel the job in this this
+     * gets invalidated and rediscovered). To stop observing services cancel the job in this
      * method is called, or use `profile` method with custom scope.
      *
      * ## Validation
@@ -874,21 +862,22 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * ```kotlin
      * override suspend fun connect(
-     *     block: suspend CoroutineScope.(HeartRateProfile.State) -> Unit,
+     *     block: suspend CoroutineScope.(Proximity.State) -> Unit,
      * ): Unit = withContext(Dispatchers.IO) {
-     *     // First, register profile.
+     *     // First, register profile. Do this only once for a peripheral.
+     *     // The profile block will get called each time the peripheral is connected.
      *     peripheral.profile(
      *         requiredServiceUuids = listOf(
-     *            ProximityProfile.linkLossServiceUuid
+     *            Proximity.linkLossServiceUuid
      *         ),
      *         optionalServiceUuids = listOf(
-     *            ProximityProfile.immediateAlertServiceUuid,
-     *            ProximityProfile.txPowerServiceUuid,
+     *            Proximity.immediateAlertServiceUuid,
+     *            Proximity.txPowerServiceUuid,
      *         ),
      *         required = true,
      *         name = "Proximity",
      *     ) { remoteServices ->
-     *         val state = ProximityProfile(remoteServices, this)
+     *         val state = ProximityImpl(remoteServices, this)
      *
      *         // Call the block with the Proximity profile state, separating Bluetooth LE from the logic.
      *         block(state)
@@ -897,7 +886,18 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *     centralManager.connect(peripheral)
      *
      *     // Await disconnection.
-     *     peripheral.awaitDisconnection()
+     *     try {
+     *        peripheral.awaitDisconnection()
+     *     } catch (e: CancellationException) {
+     *        // The scope may get canceled when user leaves the screen.
+     *        // In that case, make sure to disconnect.
+     *        // Don't disconnect when services were invalidated, as the profile will be re-launched.
+     *        if (e.cause !is InvalidAttributeException) {
+     *            peripheral.disconnect()
+     *        }
+     *        // Rethrow.
+     *        throw e
+     *     }
      * }
      * ```
      *
@@ -1037,16 +1037,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *             }
      *          }
      *          .launchIn(this)
-     *    }
-     *
-     *    // 3. Await the scope cancellation. The scope will be canceled when the device disconnects,
-     *    //    or the scope in which this method is called is canceled.
-     *    try {
-     *       awaitCancellation()
-     *    } finally {
-     *       // In this case, we want to disconnect here.
-     *       // It won't disconnect on its own.
-     *       peripheral.disconnect()
      *    }
      * }
      * ```

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Profile.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Profile.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("unused")
+
+package no.nordicsemi.kotlin.ble.client
+
+import kotlinx.coroutines.CoroutineScope
+import no.nordicsemi.kotlin.ble.core.ConnectionState
+import kotlin.uuid.Uuid
+
+/**
+ * A class representing a Bluetooth LE profile.
+ *
+ * The profiles are intended to separate the underlying GATT services and characteristics and the
+ * application logic and device API. For example, the profile can expose methods to turn a light
+ * ON or OFF, while internally it would use Bluetooth LE connection.
+ *
+ * @property requiredServiceUuids A list of UUIDs of required profile GATT services.
+ * @property optionalServiceUuids A list of UUIDs of optional profile GATT services.
+ * @property name The name of the profile. This is for convenience, used only in logging.
+ * @see Peripheral.profile
+ */
+sealed class Profile(
+    internal val requiredServiceUuids: List<Uuid>,
+    internal val optionalServiceUuids: List<Uuid> = emptyList(),
+    val name: String? = null,
+) {
+    /**
+     * This method should validate if the services contain the required characteristics,
+     * validate if the characteristics have expected properties, and store the references
+     * to the characteristics in the class properties for later use.
+     *
+     * This method is called before [initialize]. It should use [require] and [first] to validate
+     * the service and throw [IllegalArgumentException] or [NoSuchElementException] if validation fails.
+     * In that case, a required profile will cause a disconnection with
+     * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+     *
+     * #### Example
+     * ```kotlin
+     * override fun prepare(services: List<RemoteService>) {
+     *     // Link Loss service is required.
+     *     services.first { it.uuid == LINK_LOSS_SERVICE_UUID }.also { service ->
+     *        // Alert Characteristic is required.
+     *        linkLossCharacteristic = service.characteristics.first { it.uuid == ALERT_LEVEL_UUID }
+     *
+     *        require(linkLossCharacteristic.isWritable()) { "Alert level characteristic in Link Loss Service must be writable" }
+     *        require(linkLossCharacteristic.isReadable()) { "Alert level characteristic in Link Loss Service must be readable" }
+     *     }
+     *
+     *     // Immediate Alert service is optional.
+     *     services.firstOrNull { it.uuid == IMMEDIATE_ALERT_SERVICE_UUID }?.also { service ->
+     *        // If this service is found, the Alert Level characteristic is required.
+     *        immediateAlertCharacteristic = service.characteristics.first { it.uuid == ALERT_LEVEL_UUID }
+     *        require(immediateAlertCharacteristic.isWritable()) { "Alert level characteristic must be writable" }
+     *     }
+     *
+     *     // TX Power service is optional.
+     *     services.firstOrNull { it.uuid == TX_POWER_SERVICE_UUID }?.also { service ->
+     *        // If this service is found, the TX Power Level characteristic is required.
+     *        txPowerCharacteristic = service.characteristics.first { it.uuid == TX_POWER_UUID }
+     *        require(txPowerCharacteristic.isReadable()) { "TX power characteristic must be readable" }
+     *     }
+     * }
+     * ```
+     */
+    protected abstract fun prepare(services: List<RemoteService>)
+
+    /**
+     * This method should initialize the profile.
+     *
+     * The context of this method is the profile coroutine scope, which will automatically be
+     * canceled when the device gets disconnected or the services will get invalidated.
+     *
+     * #### Example
+     * ```kotlin
+     * override suspend fun CoroutineScope.initialize() {
+     *     // Subscribe to button characteristic.
+     *     txCharacteristic
+     *         .subscribe()
+     *         .map { value -> String(value) }
+     *         .onEach {
+     *             println("Received: $it")
+     *         }
+     *         .launchIn(this)
+     * }
+     * ```
+     */
+    protected abstract suspend fun CoroutineScope.initialize()
+
+    /**
+     * Executes the [prepare] and [initialize] methods of the profile.
+     *
+     * @param services A list of GATT services including all the [requiredServiceUuids] and
+     * some or all [optionalServiceUuids].
+     * @param profileScope The coroutine scope of the profile. This scope gets canceled when the
+     * services get invalidated or the device gets disconnected.
+     */
+    internal suspend fun execute(services: List<RemoteService>, profileScope: CoroutineScope) {
+        try {
+            prepare(services)
+        } catch (e: NoSuchElementException) {
+            throw IllegalArgumentException(e)
+        }
+        with(profileScope) {
+            initialize()
+        }
+    }
+
+    /**
+     * A class representing a multiservice GATT profile.
+     *
+     * This is intended for profiles that have multiple GATT services, i.e. Proximity Profile.
+     *
+     * @param requiredServiceUuids A list of UUIDs of required profile GATT services.
+     * @param optionalServiceUuids A list of UUIDs of optional profile GATT services.
+     * @param name The name of the profile. This is for convenience, used only in logging.
+     */
+    abstract class MultiService(
+        requiredServiceUuids: List<Uuid>,
+        optionalServiceUuids: List<Uuid> = emptyList(),
+        name: String? = null,
+    ): Profile(
+        requiredServiceUuids = requiredServiceUuids,
+        optionalServiceUuids = optionalServiceUuids,
+        name = name,
+    )
+
+    /**
+     * A class representing a simple GATT profile, based on a single GATT service.
+     *
+     * @param serviceUuid The UUID of the GATT service.
+     * @param name The name of the profile. This is for convenience, used only in logging.
+     */
+    abstract class Simple(
+        serviceUuid: Uuid,
+        name: String? = null,
+    ) : Profile(
+        requiredServiceUuids = listOf(serviceUuid),
+        name = name,
+    ) {
+        final override fun prepare(services: List<RemoteService>) = prepare(services.first())
+
+        /**
+         * This method should validate if the services contain the required characteristics,
+         * validate if the characteristics have expected properties, and store the references
+         * to the characteristics in the class properties for later use.
+         *
+         * This method is called before [initialize]. It should use [require] and [first] to validate
+         * the service and throw [IllegalArgumentException] or [NoSuchElementException] if validation fails.
+         * In that case, a required profile will cause a disconnection with
+         * [RequiredServiceNotFound][ConnectionState.Disconnected.Reason.RequiredServiceNotFound].
+         *
+         * ## Example
+         * ```kotlin
+         * override fun prepare(service: RemoteService) {
+         *     buttonCharacteristic = service.characteristics.first { it.uuid == BUTTON_CHARACTERISTIC_UUID }
+         *     ledCharacteristic = service.characteristics.first { it.uuid == LED_CHARACTERISTIC_UUID }
+         *
+         *     // Validate properties.
+         *     require(buttonCharacteristic.isSubscribable()) { "Button characteristic must be subscribable." }
+         *     require(ledCharacteristic.isWritable()) { "LED characteristic must be writable." }
+         * }
+         * ```
+         */
+        protected abstract fun prepare(service: RemoteService)
+    }
+}


### PR DESCRIPTION
This PR adds a new class-based approach to defining GATT Profiles.

## Overview

The `Profile` class let you define a single- or multi-service GATT Profile and register it to a `Peripheral` instance using:
```kotlin
val ledButtonProfile = LedButtonProfile()
peripheral.profile(profile: ledButtonProfile, required: true)
``` 

The profile will `prepare` and `initialize` the profile whenever services are discovered and all required services are found.
Mind, that if a peripheral reconnects or invalidates services, the profile will restart, unless the scope gets cancelled.

#### Example
```kotlin
/**
 * API of the profile.
 */
interface LedButton {
    /** The current button state on the DK. */
    val buttonState: StateFlow<Boolean>
    /** The LED state. */
    val ledState: MutableStateFlow<Boolean>
}

class LedButtonProfile: Profile.Simple(
    serviceUuid = SERVICE_UUID,
    name = "LBS",
), LedButton {
    companion object {
        val SERVICE_UUID = Uuid.parse("00001523-1212-efde-1523-785feabcd123")
        val BUTTON_CHARACTERISTIC_UUID = Uuid.parse("00001524-1212-efde-1523-785feabcd123")
        val LED_CHARACTERISTIC_UUID = Uuid.parse("00001525-1212-efde-1523-785feabcd123")
    }

    // GATT characteristics.
    private lateinit var buttonCharacteristic: RemoteCharacteristic
    private lateinit var ledCharacteristic: RemoteCharacteristic

    // Public API.
    private val _buttonState = MutableStateFlow(false)
    override val buttonState: StateFlow<Boolean> = _buttonState.asStateFlow()
    override val ledState: MutableStateFlow<Boolean> = MutableStateFlow(false)

    // Implementation.
    override fun prepare(service: RemoteService) {
        // This should always pass.
        require(service.uuid == SERVICE_UUID)

        // Obtain characteristics from the service.
        buttonCharacteristic = service.characteristics.first { it.uuid == BUTTON_CHARACTERISTIC_UUID }
        ledCharacteristic = service.characteristics.first { it.uuid == LED_CHARACTERISTIC_UUID }

        // Validate properties.
        require(buttonCharacteristic.isSubscribable()) { "Button characteristic must be subscribable." }
        require(ledCharacteristic.isWritable()) { "LED characteristic must be writable." }
    }

    override suspend fun CoroutineScope.initialize() {
        // Note: All try-catches are skipped for cimplicity.

        // Subscribe to button characteristic.
        buttonCharacteristic
            .subscribe()
            .map { value -> value.singleOrNull() == 1.toByte() }
            .onEach { isPressed -> _buttonState.update { isPressed } }
            .launchIn(this)

        // Handle LED state updates.
        ledState
            .map { isOn -> byteArrayOf(if (isOn) 1 else 0) }
            .onEach { value ->
                try {
                    ledCharacteristic.write(value)
                } catch (e: OperationFailedException) {
                    println("Writing LED characteristic failed: ${e.message}")
                }
            }
            .launchIn(this)

        // Read current Button state.
        try {
            val currentState = buttonCharacteristic.read()
            _buttonState.update { currentState.singleOrNull() == 1.toByte() }
        } catch (e: OperationFailedException) {
            println("Reading button characteristic failed: ${e.message}")
        }
    }
}
```