### PR TITLE
[Bugfix] Service changed while bonding

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeGattCallback.kt
@@ -33,6 +33,7 @@
 
 package no.nordicsemi.kotlin.ble.client.android.internal
 
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
@@ -250,7 +251,11 @@ internal class NativeGattCallback(
         // However, since API 26 it was possible to detect it by listening to connection
         // parameters update, which decreased the interval to 7.5 ms during service discovery.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
-            isServiceDiscoveryComplete && interval == 6 /* 7.5 ms */ ) {
+            isServiceDiscoveryComplete && interval == 6 /* 7.5 ms */  &&
+            // Don't invalidate services while bonding.
+            // There may be an ongoing request that triggered bonding.
+            gatt.device.bondState != BluetoothDevice.BOND_BONDING) {
+            logger?.warn(Layer.SMP) { "Inferred ongoing Service Changed procedure" }
             onServiceChanged(gatt)
         }
     }


### PR DESCRIPTION
The `onServiceChanged()` method was added in Android S (API 31).
Before, the service changed event is inferred by checking connection parameters. 

Some Android phones, i.e. Samsung S8 with Android 9 Pie, perform service discovery also during bonding. This does not, however, invalidates services.
Moreover, invalidating services during bonding would cancel awaiting expected callback for the initial request that triggered bonding in the first place. Another request could then be started (with unlocked mutex) and would have been ignored by the system.