### PR TITLE
[Feature] Profiles vs Service instances

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -373,7 +373,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * @param event The GATT event to process.
      */
-        protected open suspend fun handle(event: GattEvent) {
+    protected open suspend fun handle(event: GattEvent) {
         when (event) {
             is ConnectionStateChanged -> {
                 // If the state didn't change, ignore the event.
@@ -478,7 +478,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
     /**
      * This method is called when the peripheral is connected.
      */
-        protected open suspend fun initiateConnection() {
+    protected open suspend fun initiateConnection() {
         // If services are observed, start service discovery.
         // This may happen when services() was called before the peripheral connected.
         if (serviceDiscoveryRequested) {
@@ -491,7 +491,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *
      * This method does nothing if [servicesDiscovered] is `true`.
      */
-        private fun discoverServices(uuids: List<Uuid>) {
+    private fun discoverServices(uuids: List<Uuid>) {
         if (!servicesDiscovered) {
             servicesDiscovered = true
             scope.launch {
@@ -579,7 +579,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * services with given UUIDs, otherwise it will contain all services returned by the
      * system. If the returned list is empty, the service was not found on the peripheral.
      */
-        fun services(uuids: List<Uuid> = emptyList()): StateFlow<RemoteServices> {
+    fun services(uuids: List<Uuid> = emptyList()): StateFlow<RemoteServices> {
         // Mark that service discovery was requested. This is useful when the peripheral
         // reconnects but the services observer was already set.
         serviceDiscoveryRequested = true
@@ -675,7 +675,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * an app registers multiple profiles, to easily distinguish them in logs.
      * @param block The profile implementation.
      */
-        suspend fun profile(
+    suspend fun profile(
         serviceUuid: Uuid,
         required: Boolean = true,
         name: String? = null,
@@ -802,7 +802,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * an app registers multiple profiles, to easily distinguish them in logs.
      * @param block The profile implementation.
      */
-        fun profile(
+    fun profile(
         scope: CoroutineScope,
         serviceUuid: Uuid,
         required: Boolean = true,
@@ -914,7 +914,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * an app registers multiple profiles, to easily distinguish them in logs.
      * @param block The profile implementation.
      */
-        suspend fun profile(
+    suspend fun profile(
         requiredServiceUuids: List<Uuid>,
         optionalServiceUuids: List<Uuid> = emptyList(),
         required: Boolean = true,
@@ -1052,7 +1052,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * an app registers multiple profiles, to easily distinguish them in logs.
      * @param block The profile implementation.
      */
-        fun profile(
+    fun profile(
         scope: CoroutineScope,
         requiredServiceUuids: List<Uuid>,
         optionalServiceUuids: List<Uuid> = emptyList(),

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Profile.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Profile.kt
@@ -140,6 +140,10 @@ sealed class Profile(
      *
      * This is intended for profiles that have multiple GATT services, i.e. Proximity Profile.
      *
+     * Note, the [prepare] method may be called with a list of services containing multiple
+     * instances of the same service if returned by the service discovery. For example, if a device
+     * has multiple batteries, it may expose their level with a *Battery Service* for each of them.
+     *
      * @param requiredServiceUuids A list of UUIDs of required profile GATT services.
      * @param optionalServiceUuids A list of UUIDs of optional profile GATT services.
      * @param name The name of the profile. This is for convenience, used only in logging.
@@ -157,6 +161,17 @@ sealed class Profile(
     /**
      * A class representing a simple GATT profile, based on a single GATT service.
      *
+     * This is intended for profiles that have a single GATT service, i.e. Battery Profile.
+     *
+     * ## Multiple instances of the same service
+     *
+     * In rare cases, a peripheral may have multiple instances of the same service, e.g. multiple
+     * batteries reporting their level, each with a different instance of a *Battery Service*.
+     *
+     * Override [instance] method to pick a desired instance of a remote service.
+     *
+     * Note, that the list of services contains only GATT services with specified service UUID.
+     *
      * @param serviceUuid The UUID of the GATT service.
      * @param name The name of the profile. This is for convenience, used only in logging.
      */
@@ -167,7 +182,22 @@ sealed class Profile(
         requiredServiceUuids = listOf(serviceUuid),
         name = name,
     ) {
-        final override fun prepare(services: List<RemoteService>) = prepare(services.first())
+        final override fun prepare(services: List<RemoteService>) = prepare(instance(services))
+
+        /**
+         * This method should select a single service instance from the list of identical services
+         * returned by the service discovery.
+         *
+         * The [services] will contain only instances of GATT services with the given UUID.
+         * Use [RemoteService.instanceId] to distinguish between instances.
+         *
+         * ## Multiple instances of the same service
+         *
+         * By default, this method should return the first service instance. However, in some cases,
+         * a peripheral may have multiple instances of the same service, e.g. multiple batteries
+         * reporting their level, each with a different instance of a *Battery Service*.
+         */
+        protected open fun instance(services: List<RemoteService>): RemoteService = services.first()
 
         /**
          * This method should validate if the services contain the required characteristics,

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/ScannerViewModel.kt
@@ -188,9 +188,9 @@ class ScannerViewModel @Inject constructor(
                             // The observers will get canceled when the connection scope gets canceled,
                             // that is when the device is manually disconnected in case of auto connect,
                             // or disconnects for any reason when auto connect was false.
-                            observerPhy(peripheral, this)
+                            observePhy(peripheral, this)
                             observeConnectionParameters(peripheral, this)
-                            observerServices(peripheral, this)
+                            observeServices(peripheral, this)
 
                             installLbsProfile(peripheral, required = false) { state ->
                                 // When the Button is long-clicked, cancel the profile scope.
@@ -320,11 +320,11 @@ class ScannerViewModel @Inject constructor(
             Timber.i("Connection priority changed to HIGH")
             Timber.i("New connection parameters: $newConnectionParameters")
         } catch (e: Exception) {
-            Timber.e(e, "OMG!")
+            Timber.e("Peripheral disconnected before initialization completed: ${e.message}")
         }
     }
 
-    private fun observerPhy(peripheral: Peripheral, scope: CoroutineScope) {
+    private fun observePhy(peripheral: Peripheral, scope: CoroutineScope) {
         peripheral.phy
             .onEach {
                 Timber.i("PHY changed to: $it")
@@ -352,7 +352,7 @@ class ScannerViewModel @Inject constructor(
             .launchIn(scope)
     }
 
-        private fun observerServices(peripheral: Peripheral, scope: CoroutineScope) {
+    private fun observeServices(peripheral: Peripheral, scope: CoroutineScope) {
         // Services will change multiple times. Initially, the services() will emit null (event 1).
         // When services are discovered, it will emit the list of services (event 2).
         // If the services change later, it will emit null again (event 3) and the new list (event 4).
@@ -380,6 +380,7 @@ class ScannerViewModel @Inject constructor(
                                 val value = remoteCharacteristic.read()
                                 Timber.i("- Value of ${remoteCharacteristic.uuid}: 0x${value.toHexString()}")
                             } catch (e: Exception) {
+                                if (e is InvalidAttributeException) throw e
                                 if (expectError) {
                                     Timber.w("- Value of ${remoteCharacteristic.uuid}: Read not permitted")
                                 } else {
@@ -392,6 +393,7 @@ class ScannerViewModel @Inject constructor(
                                     val descValue = descriptor.read()
                                     Timber.i("   - Value of descriptor ${descriptor.uuid}: 0x${descValue.toHexString()}")
                                 } catch (e: Exception) {
+                                    if (e is InvalidAttributeException) throw e
                                     if (e is OperationFailedException && e.reason == OperationStatus.ReadNotPermitted) {
                                         // This is expected for Client Characteristic Configuration Descriptor of non-notifiable characteristics.
                                         Timber.w("   - Value of descriptor ${descriptor.uuid}: Read not permitted")
@@ -444,6 +446,7 @@ class ScannerViewModel @Inject constructor(
                                     }
                                     .launchIn(scope)
                             } catch (e: Exception) {
+                                if (e is InvalidAttributeException) throw e
                                 if (!expectError) {
                                     Timber.e("($ce) Failed to subscribe to ${remoteCharacteristic.uuid}: ${e.message}")
                                 }
@@ -469,7 +472,7 @@ class ScannerViewModel @Inject constructor(
             .launchIn(scope)
     }
 
-        private suspend fun installLbsProfile(
+    private suspend fun installLbsProfile(
         peripheral: Peripheral,
         required: Boolean,
         block: suspend CoroutineScope.(LedButtonProfile.State) -> Unit,
@@ -477,6 +480,7 @@ class ScannerViewModel @Inject constructor(
         peripheral.profile(
             serviceUuid = LedButtonProfile.SERVICE_UUID,
             required = required,
+            name = "LBS",
         ) { lbs ->
             val state = LedButtonServiceImpl(lbs, this)
             Timber.i("LBS: LED Button Service found")

--- a/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
+++ b/sample/src/main/java/no/nordicsemi/kotlin/ble/android/sample/scanner/profile/impl/LedButtonServiceImpl.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.kotlin.ble.android.sample.scanner.profile.impl
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
@@ -38,6 +39,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
@@ -180,10 +182,15 @@ class LedButtonServiceImpl(
                 // By having a local mutable flow we call subscribe() only once.
                 try {
                     buttonCharacteristic.subscribe()
+                        .catch { t ->
+                            Timber.w("Button characteristic subscription failed: ${t.message}")
+                        }
                         .collect { flow.emit(it.state) }
-                } catch (e: Exception) {
-                    Timber.d("Stopped observing button events")
+                } catch (e: CancellationException) {
+                    // Rethrow the cancellation exception.
                     throw e
+                } catch (e: Exception) {
+                    Timber.w("Button characteristic subscription failed: ${e.message}")
                 }
             }
         }


### PR DESCRIPTION
It is possible for a Bluetooth LE peripheral to have multiple instances of the same GATT service. For example, a device with multiple batteries may report their level using multiple instances of *Battery Service*, one for each battery.

The new `profile(...)` methods in `Peripheral` allow to register handlers (`Profile`s) for services. The `Profile.Simple` should be used for a simple, single-service profile. However, in some cases, when a device has multiple instances of the same service, one would like to register a `Profile` class for each service instance. 

Until now it was possible using `Profile.MutliService`, which forwarded a list of service to `prepare(..)`. The list in that case would contain a list of services, all with the same UUID. A single object would be then responsible for managing all service instances.

Now, after adding `instance(services: List<RemoteService>): RemoteService` user can choose which service is to be used. Multiple instances of `Profile.Simple` can be registered, one for each service instance.

Use `service.instanceId` to distinguish between instances.