### PR TITLE
[Feature] add call site tracking for suspending functions

### DIFF
--- a/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeCentralManagerImpl.kt
+++ b/client-android/src/main/java/no/nordicsemi/kotlin/ble/client/android/internal/NativeCentralManagerImpl.kt
@@ -60,6 +60,7 @@ import no.nordicsemi.kotlin.ble.client.android.ScanResult
 import no.nordicsemi.kotlin.ble.client.android.exception.ScanningFailedToStartException
 import no.nordicsemi.kotlin.ble.core.BondState
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothUnavailableException
+import no.nordicsemi.kotlin.ble.core.internal.CallSiteException
 import no.nordicsemi.kotlin.ble.core.log.Layer
 import no.nordicsemi.kotlin.ble.environment.android.NativeAndroidEnvironment
 import no.nordicsemi.kotlin.log.Log
@@ -141,106 +142,121 @@ internal class NativeCentralManagerImpl(
     override fun scan(
         timeout: Duration,
         filter: ConjunctionFilterScope.() -> Unit
-    ): Flow<ScanResult> = callbackFlow {
-        // Ensure the central manager has not been closed.
-        try {
-            ensureOpen()
-        } catch (e: Exception) {
-            close(e)
-            return@callbackFlow
-        }
+    ): Flow<ScanResult> {
+        // Captured immediately, on the caller's thread, before the flow below is even built.
+        val calledHere = CallSiteException("scan() was called here")
 
-        // Ensure the Bluetooth is enabled and Bluetooth LE Scanner is available.
-        val scanner = environment.bluetoothManager?.adapter
-            ?.takeIf { it.isEnabled }
-            ?.bluetoothLeScanner
-            ?: run {
-                close(BluetoothUnavailableException())
+        return callbackFlow {
+            // Captured when collection of the flow actually starts, which may happen later and
+            // on a different coroutine than the one that called scan().
+            val collectedHere = CallSiteException("scan() Flow started being collected here")
+
+            fun closeWithCallSite(e: Throwable) {
+                e.addSuppressed(calledHere)
+                e.addSuppressed(collectedHere)
+                close(e)
+            }
+
+            // Ensure the central manager has not been closed.
+            try {
+                ensureOpen()
+            } catch (e: Exception) {
+                closeWithCallSite(e)
                 return@callbackFlow
             }
 
-        // Verify the BLUETOOTH_SCAN permission is granted (Android 12+).
-        try {
-            checkScanningPermission()
-        } catch (e: Exception) {
-            close(e)
-            return@callbackFlow
-        }
-
-        // Build the filter based on the provided builder.
-        val filters = ConjunctionFilter().apply(filter).filters
-
-        // Use the most optimal scan mode for low latency immediate scanning.
-        val settings = NativeScanSettings.Builder()
-            .apply {
-                // TODO Scan settings could be configurable.
-                setScanMode(NativeScanSettings.SCAN_MODE_LOW_LATENCY)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    setLegacy(false)
-                    setPhy(NativeScanSettings.PHY_LE_ALL_SUPPORTED)
+            // Ensure the Bluetooth is enabled and Bluetooth LE Scanner is available.
+            val scanner = environment.bluetoothManager?.adapter
+                ?.takeIf { it.isEnabled }
+                ?.bluetoothLeScanner
+                ?: run {
+                    closeWithCallSite(BluetoothUnavailableException())
+                    return@callbackFlow
                 }
-            }
-            .build()
 
-        // Define the callback that will emit scan results.
-        val callback: NativeScanCallback = object : NativeScanCallback() {
-            override fun onScanResult(callbackType: Int, result: NativeScanResult) {
-                // A result matching the offloaded filter was found, convert it to ScanResult.
-                val scanResult = result.toScanResult(
-                    peripheral = { device, name ->
-                        peripheral(device.address) {
-                            Peripheral(
-                                scope = scope,
-                                impl = NativeExecutor(environment.applicationContext, device, name)
-                                    .apply {
-                                        _bondState
-                                            .filter { (address, _) -> address == device.address }
-                                            .onEach { (_, state) -> onBondStateChanged(state) }
-                                            .launchIn(scope)
-                                    }
-                            ).also { p -> p.logger = logger }
-                        }
+            // Verify the BLUETOOTH_SCAN permission is granted (Android 12+).
+            try {
+                checkScanningPermission()
+            } catch (e: Exception) {
+                closeWithCallSite(e)
+                return@callbackFlow
+            }
+
+            // Build the filter based on the provided builder.
+            val filters = ConjunctionFilter().apply(filter).filters
+
+            // Use the most optimal scan mode for low latency immediate scanning.
+            val settings = NativeScanSettings.Builder()
+                .apply {
+                    // TODO Scan settings could be configurable.
+                    setScanMode(NativeScanSettings.SCAN_MODE_LOW_LATENCY)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        setLegacy(false)
+                        setPhy(NativeScanSettings.PHY_LE_ALL_SUPPORTED)
                     }
-                ) ?: return
+                }
+                .build()
 
-                // Check other filters that cannot be checked by the controller.
-                if (filters?.match(scanResult) == false) return
+            // Define the callback that will emit scan results.
+            val callback: NativeScanCallback = object : NativeScanCallback() {
+                override fun onScanResult(callbackType: Int, result: NativeScanResult) {
+                    // A result matching the offloaded filter was found, convert it to ScanResult.
+                    val scanResult = result.toScanResult(
+                        peripheral = { device, name ->
+                            peripheral(device.address) {
+                                Peripheral(
+                                    scope = scope,
+                                    impl = NativeExecutor(environment.applicationContext, device, name)
+                                        .apply {
+                                            _bondState
+                                                .filter { (address, _) -> address == device.address }
+                                                .onEach { (_, state) -> onBondStateChanged(state) }
+                                                .launchIn(scope)
+                                        }
+                                ).also { p -> p.logger = logger }
+                            }
+                        }
+                    ) ?: return
 
-                trySend(scanResult)
-            }
+                    // Check other filters that cannot be checked by the controller.
+                    if (filters?.match(scanResult) == false) return
 
-            override fun onBatchScanResults(results: List<NativeScanResult>) {
-                results.forEach { onScanResult(0, it) }
-            }
+                    trySend(scanResult)
+                }
 
-            override fun onScanFailed(errorCode: Int) {
-                with (ScanningFailedToStartException(errorCode.errorCodeToReason())) {
-                    logger?.error(Layer.GAP, this)
-                    close(this)
+                override fun onBatchScanResults(results: List<NativeScanResult>) {
+                    results.forEach { onScanResult(0, it) }
+                }
+
+                override fun onScanFailed(errorCode: Int) {
+                    with (ScanningFailedToStartException(errorCode.errorCodeToReason())) {
+                        logger?.error(Layer.GAP, this)
+                        closeWithCallSite(this)
+                    }
                 }
             }
-        }
 
-        // Finally, start the scan.
-        logger?.trace(Layer.GAP) {
-            "Starting scanning with ${filters?.let { "filters: $it" } ?: "no filters"}"
-        }
-        scanner.startScan(filters?.toNative(), settings, callback)
-
-        // Set a timeout to stop the scan.
-        if (timeout > 0.milliseconds) {
-            launch(Dispatchers.IO) {
-                // If the flow is canceled before the timeout, the delay() method will throw
-                // a CancellationException, which will be ignored.
-                delay(timeout)
-                // If we reached the timeout, close the flow manually.
-                logger?.trace(Layer.GAP) { "Scanning timed out after $timeout" }
-                close()
+            // Finally, start the scan.
+            logger?.trace(Layer.GAP) {
+                "Starting scanning with ${filters?.let { "filters: $it" } ?: "no filters"}"
             }
-        }
-        awaitClose {
-            scanner.stopScan(callback)
-            logger?.trace(Layer.GAP) { "Scanning stopped" }
+            scanner.startScan(filters?.toNative(), settings, callback)
+
+            // Set a timeout to stop the scan.
+            if (timeout > 0.milliseconds) {
+                launch(Dispatchers.IO) {
+                    // If the flow is canceled before the timeout, the delay() method will throw
+                    // a CancellationException, which will be ignored.
+                    delay(timeout)
+                    // If we reached the timeout, close the flow manually.
+                    logger?.trace(Layer.GAP) { "Scanning timed out after $timeout" }
+                    close()
+                }
+            }
+            awaitClose {
+                scanner.stopScan(callback)
+                logger?.trace(Layer.GAP) { "Scanning stopped" }
+            }
         }
     }
 

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -70,6 +70,7 @@ import no.nordicsemi.kotlin.ble.core.Peer
 import no.nordicsemi.kotlin.ble.core.Phy
 import no.nordicsemi.kotlin.ble.core.Service
 import no.nordicsemi.kotlin.ble.core.WriteType
+import no.nordicsemi.kotlin.ble.core.internal.withCallSite
 import no.nordicsemi.kotlin.ble.core.log.Layer
 import no.nordicsemi.kotlin.log.Log
 import kotlin.coroutines.cancellation.CancellationException
@@ -1439,11 +1440,11 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * @throws OperationFailedException If reading RSSI could not be initiated.
      * @throws SecurityException If BLUETOOTH_CONNECT permission is denied.
      */
-    suspend fun readRssi(): Int {
+    suspend fun readRssi(): Int = withCallSite("readRssi") {
         check (isConnected) {
             throw PeripheralNotConnectedException()
         }
-        return OperationMutex.withLock {
+        OperationMutex.withLock {
             logger?.trace(Layer.LINK) { "Reading RSSI" }
             impl.events
                 .onSubscription {
@@ -1487,54 +1488,56 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * @param reason The reason for disconnection. Use [Success][ConnectionState.Disconnected.Reason.Success]
      * when disconnection was initiated by the user.
      */
-    internal suspend fun disconnect(reason: ConnectionState.Disconnected.Reason) = withContext(NonCancellable) {
-        OperationMutex.withLock {
-            // Depending on the state...
-            when (state.value) {
-                is ConnectionState.Disconnected -> {
-                    // Make sure auto-connection is closed.
+    internal suspend fun disconnect(reason: ConnectionState.Disconnected.Reason) = withCallSite("disconnect") {
+        withContext(NonCancellable) {
+            OperationMutex.withLock {
+                // Depending on the state...
+                when (state.value) {
+                    is ConnectionState.Disconnected -> {
+                        // Make sure auto-connection is closed.
+                        close()
+                        return@withLock
+                    }
+
+                    is ConnectionState.Disconnecting -> {
+                        // Skip..
+                    }
+
+                    is ConnectionState.Connecting -> {
+                        // Cancel the connection attempt.
+                        logger?.trace(Layer.GAP) { "Cancelling connection to ${this@Peripheral}" }
+                        _state.update { ConnectionState.Disconnecting }
+                    }
+
+                    is ConnectionState.Connected -> {
+                        // Disconnect from the peripheral.
+                        logger?.trace(Layer.GAP) { "Disconnecting from ${this@Peripheral}" }
+                        _state.update { ConnectionState.Disconnecting }
+                    }
+                }
+
+                // Disconnect and wait until it is disconnected, then close.
+                try {
+                    if (!impl.isClosed) {
+                        await(
+                            action = { impl.disconnect(reason) },
+                            condition = { it.isDisconnected },
+                            timeout = 500.milliseconds
+                        )
+                    }
+                } catch (e: TimeoutCancellationException) {
+                    if (!isDisconnected) {
+                        logger?.warn(Layer.GAP) { "Disconnection takes longer than expected, closing" }
+                    }
+                } finally {
                     close()
-                    return@withLock
-                }
-
-                is ConnectionState.Disconnecting -> {
-                    // Skip..
-                }
-
-                is ConnectionState.Connecting -> {
-                    // Cancel the connection attempt.
-                    logger?.trace(Layer.GAP) { "Cancelling connection to ${this@Peripheral}" }
-                    _state.update { ConnectionState.Disconnecting }
-                }
-
-                is ConnectionState.Connected -> {
-                    // Disconnect from the peripheral.
-                    logger?.trace(Layer.GAP) { "Disconnecting from ${this@Peripheral}" }
-                    _state.update { ConnectionState.Disconnecting }
-                }
-            }
-
-            // Disconnect and wait until it is disconnected, then close.
-            try {
-                if (!impl.isClosed) {
-                    await(
-                        action = { impl.disconnect(reason) },
-                        condition = { it.isDisconnected },
-                        timeout = 500.milliseconds
+                    // If before calling disconnect() the state was not Connected (i.e. Connecting),
+                    // the state at this point will be Disconnecting. Change it to Disconnected manually.
+                    _state.compareAndSet(
+                        expect = ConnectionState.Disconnecting,
+                        update = ConnectionState.Disconnected(reason)
                     )
                 }
-            } catch (e: TimeoutCancellationException) {
-                if (!isDisconnected) {
-                    logger?.warn(Layer.GAP) { "Disconnection takes longer than expected, closing" }
-                }
-            } finally {
-                close()
-                // If before calling disconnect() the state was not Connected (i.e. Connecting),
-                // the state at this point will be Disconnecting. Change it to Disconnected manually.
-                _state.compareAndSet(
-                    expect = ConnectionState.Disconnecting,
-                    update = ConnectionState.Disconnected(reason)
-                )
             }
         }
     }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -52,6 +52,8 @@ import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+import no.nordicsemi.kotlin.ble.core.internal.CallSiteException
+import no.nordicsemi.kotlin.ble.core.internal.withCallSite
 import no.nordicsemi.kotlin.ble.core.util.MergeResult
 import no.nordicsemi.kotlin.ble.core.util.mergeIndexed
 
@@ -117,7 +119,7 @@ abstract class BaseRemoteCharacteristic(
     final override val isNotifying: Boolean
         get() = owner != null && _isNotifying
 
-    final override suspend fun setNotifying(enabled: Boolean) {
+    final override suspend fun setNotifying(enabled: Boolean) = withCallSite("setNotifying") {
         // Check whether the characteristic wasn't invalidated.
         requireNotNull(owner) {
             throw InvalidAttributeException()
@@ -125,7 +127,7 @@ abstract class BaseRemoteCharacteristic(
 
         // If the current state of notifications is the same as the requested state, return.
         if (enabled == isNotifying)
-            return
+            return@withCallSite
 
         // Verify that the characteristic can be subscribed to.
         require(isSubscribable()) {
@@ -156,7 +158,7 @@ abstract class BaseRemoteCharacteristic(
         _isNotifying = enabled
     }
 
-    final override suspend fun read(): ByteArray {
+    final override suspend fun read(): ByteArray = withCallSite("read") {
         // Check whether the characteristic wasn't invalidated.
         requireNotNull(owner) {
             throw InvalidAttributeException()
@@ -168,7 +170,7 @@ abstract class BaseRemoteCharacteristic(
         }
 
         // Read the characteristic value and await the result.
-        return OperationMutex.withLock {
+        OperationMutex.withLock {
             events
                 .onSubscription {
                     try {
@@ -206,7 +208,7 @@ abstract class BaseRemoteCharacteristic(
         }
     }
 
-    final override suspend fun write(data: ByteArray, writeType: WriteType) {
+    final override suspend fun write(data: ByteArray, writeType: WriteType) = withCallSite("write") {
         // Check whether the characteristic wasn't invalidated.
         requireNotNull(owner) {
             throw InvalidAttributeException()
@@ -263,11 +265,13 @@ abstract class BaseRemoteCharacteristic(
         merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
         filter: (ByteArray) -> Boolean,
         trigger: suspend RemoteCharacteristic.() -> Unit,
-    ): ByteArray = subscribe(trigger)
-        .filter(rawDataFilter)
-        .mergeIndexed(merge)
-        .firstOrNull(filter)
-        ?: throw InvalidAttributeException()
+    ): ByteArray = withCallSite("waitForValueChange") {
+        subscribe(trigger)
+            .filter(rawDataFilter)
+            .mergeIndexed(merge)
+            .firstOrNull(filter)
+            ?: throw InvalidAttributeException()
+    }
 
     override fun subscribe(
         onSubscription: suspend RemoteCharacteristic.() -> Unit
@@ -282,12 +286,26 @@ abstract class BaseRemoteCharacteristic(
             throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
         }
 
+        // Captured immediately, on the caller's thread, before the flow below is even built.
+        val calledHere = CallSiteException("subscribe() was called here")
+
         return events
             .onSubscription {
-                // First, make sure the notifications or indications are enabled.
-                setNotifying(true)
-                // Then, invoke the user callback.
-                onSubscription()
+                // Captured when collection of the flow actually starts, which may happen later
+                // and on a different coroutine than the one that called subscribe().
+                val collectedHere = CallSiteException("subscribe() Flow started being collected here")
+                try {
+                    // First, make sure the notifications or indications are enabled.
+                    setNotifying(true)
+                    // Then, invoke the user callback.
+                    onSubscription()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    e.addSuppressed(calledHere)
+                    e.addSuppressed(collectedHere)
+                    throw e
+                }
             }
             .takeWhile { !it.isServiceInvalidatedEvent }
             .filterIsInstance(CharacteristicChanged::class)

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -46,6 +46,7 @@ import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.ValueDoesNotMatchException
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+import no.nordicsemi.kotlin.ble.core.internal.withCallSite
 
 abstract class BaseRemoteDescriptor(
     parent: RemoteCharacteristic,
@@ -108,7 +109,7 @@ abstract class BaseRemoteDescriptor(
      */
     abstract fun OperationEvent.matches(): Boolean
 
-    final override suspend fun read(): ByteArray {
+    final override suspend fun read(): ByteArray = withCallSite("read") {
         // Check whether the descriptor wasn't invalidated.
         requireNotNull(owner) {
             throw InvalidAttributeException()
@@ -119,7 +120,7 @@ abstract class BaseRemoteDescriptor(
             throw OperationFailedException(OperationStatus.ReadNotPermitted)
         }
 
-        return OperationMutex.withLock {
+        OperationMutex.withLock {
             events
                 .onSubscription {
                     try {
@@ -157,7 +158,7 @@ abstract class BaseRemoteDescriptor(
         }
     }
 
-    final override suspend fun write(data: ByteArray) {
+    final override suspend fun write(data: ByteArray) = withCallSite("write") {
         // Check whether the descriptor wasn't invalidated.
         requireNotNull(owner) {
             throw InvalidAttributeException()

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/internal/CallSite.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/internal/CallSite.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.core.internal
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A marker exception whose only purpose is to capture a stack trace at a point of interest, e.g.
+ * where a public API function was called, or where a [kotlinx.coroutines.flow.Flow] it returned
+ * started being collected.
+ *
+ * @see <a href="https://github.com/nordicsemi/Kotlin-BLE-Library/issues/330">Issue #330</a>
+ */
+class CallSiteException(message: String) : Exception(message)
+
+/**
+ * Runs [block], and if it throws anything other than [CancellationException], attaches the call
+ * site of this function as a suppressed [CallSiteException] before rethrowing.
+ *
+ * Intended to wrap the body of public suspending API functions that internally collect a
+ * [Flow], so that a failure reported deep inside that flow still points back to the caller.
+ *
+ * @param operation The name of the wrapped public API method, used only in the exception message.
+ */
+suspend fun <T> withCallSite(operation: String, block: suspend () -> T): T {
+    val callSite = CallSiteException("$operation() was called here")
+    try {
+        return block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        e.addSuppressed(callSite)
+        throw e
+    }
+}


### PR DESCRIPTION
This PR fixes #330.

This pull request introduces a new mechanism for improved debugging and error tracing throughout the BLE client library. The main enhancement is the introduction of `CallSiteException` and the `withCallSite` utility, which help capture and propagate call site information for asynchronous and suspending BLE operations. This makes it easier to trace the origin of errors, especially those that occur deep within coroutine flows.

**Error tracing and debugging improvements:**

* Added new `CallSiteException` class and `withCallSite` suspend function in `core/internal/CallSite.kt` to capture stack traces at public API boundaries and attach them as suppressed exceptions for better error diagnostics.
* Updated public suspending API methods in `Peripheral`, `BaseRemoteCharacteristic`, and `BaseRemoteDescriptor` (e.g., `read`, `write`, `setNotifying`, `disconnect`, and `waitForValueChange`) to wrap their bodies with `withCallSite`, ensuring that exceptions thrown within these methods include call site information. 
* Enhanced flow-based APIs (such as `scan` and `subscribe`) to capture both the call site and the flow collection site, attaching both as suppressed exceptions when errors are propagated, further improving traceability of asynchronous errors.

These changes collectively make it much easier to identify where in user code BLE operations were initiated, which is especially valuable for debugging complex asynchronous workflows.