### PR TITLE
[Improvement] `isSubscribable()` checks also for CCCD

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -282,7 +282,7 @@ abstract class BaseRemoteCharacteristic(
         }
 
         // Verify that the characteristic can be subscribed to.
-        require(isSubscribable() && descriptors.cccd() != null) {
+        require(isSubscribable()) {
             throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
         }
 

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/Characteristic.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/Characteristic.kt
@@ -103,12 +103,14 @@ interface Characteristic<D: Descriptor> {
     }
 
     /**
-     * Checks whether the characteristic has
-     * [CharacteristicProperty.NOTIFY] or
-     * [CharacteristicProperty.INDICATE] property.
+     * Checks whether the characteristic can be subscribed to.
+     *
+     * This method checks if the characteristic has
+     * [CharacteristicProperty.NOTIFY] or [CharacteristicProperty.INDICATE] property,
+     * and the Client Characteristic Configuration descriptor.
      */
     fun isSubscribable() = properties.any {
         it == CharacteristicProperty.NOTIFY ||
         it == CharacteristicProperty.INDICATE
-    }
+    } && descriptors.any { it.isClientCharacteristicConfiguration }
 }


### PR DESCRIPTION
Before it was possible to `subscribe()` to fail despite checking first for `isSubscribable()`, as `subscribe()` requires the Client Characteristic Configuration Descriptor (CCCD).