### PR TITLE
[Feature] Throw `SecurityException` when trying to access restricted attribute

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -67,7 +67,11 @@ abstract class BaseRemoteCharacteristic(
      * A flag indicating whether reliable write is enabled.
      */
     protected val isReliableWriteEnabled: Boolean
-        get() = service.owner?.executor?.isReliableWriteEnabled ?: false
+        get() = owner?.executor?.isReliableWriteEnabled ?: false
+
+    /** Cached restriction flag. */
+    private val _isRestricted by lazy { super.isRestricted() }
+    override fun isRestricted(): Boolean = _isRestricted
 
     abstract fun setCharacteristicNotification(enabled: Boolean)
 
@@ -121,8 +125,13 @@ abstract class BaseRemoteCharacteristic(
 
     final override suspend fun setNotifying(enabled: Boolean) = withCallSite("setNotifying") {
         // Check whether the characteristic wasn't invalidated.
-        requireNotNull(owner) {
+        val owner = requireNotNull(owner) {
             throw InvalidAttributeException()
+        }
+
+        // Check whether accessing the attribute is permitted.
+        require(owner.executor.environment.isSystem || !isRestricted()) {
+            throw SecurityException("Subscribing to value changes from characteristic $uuid is not permitted")
         }
 
         // If the current state of notifications is the same as the requested state, return.
@@ -160,8 +169,13 @@ abstract class BaseRemoteCharacteristic(
 
     final override suspend fun read(): ByteArray = withCallSite("read") {
         // Check whether the characteristic wasn't invalidated.
-        requireNotNull(owner) {
+        val owner = requireNotNull(owner) {
             throw InvalidAttributeException()
+        }
+
+        // Check whether accessing the attribute is permitted.
+        require(owner.executor.environment.isSystem || !isRestricted()) {
+            throw SecurityException("Reading characteristic $uuid is not permitted")
         }
 
         // Verify that the characteristic can be read.
@@ -212,8 +226,13 @@ abstract class BaseRemoteCharacteristic(
 
     final override suspend fun write(data: ByteArray, writeType: WriteType) = withCallSite("write") {
         // Check whether the characteristic wasn't invalidated.
-        requireNotNull(owner) {
+        val owner = requireNotNull(owner) {
             throw InvalidAttributeException()
+        }
+
+        // Check whether accessing the attribute is permitted.
+        require(owner.executor.environment.isSystem || !isRestricted()) {
+            throw SecurityException("Writing characteristic $uuid is not permitted")
         }
 
         // Verify that the characteristic can be written.
@@ -281,8 +300,13 @@ abstract class BaseRemoteCharacteristic(
         onSubscription: suspend RemoteCharacteristic.() -> Unit
     ): Flow<ByteArray> {
         // Check whether the characteristic wasn't invalidated.
-        requireNotNull(owner) {
+        val owner = requireNotNull(owner) {
             throw InvalidAttributeException()
+        }
+
+        // Check whether accessing the attribute is permitted.
+        require(owner.executor.environment.isSystem || !isRestricted()) {
+            throw SecurityException("Subscribing to value changes from characteristic $uuid is not permitted")
         }
 
         // Verify that the characteristic can be subscribed to.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -64,7 +64,11 @@ abstract class BaseRemoteDescriptor(
      * A flag indicating whether reliable write is enabled.
      */
     protected val isReliableWriteEnabled: Boolean
-        get() = characteristic.owner?.executor?.isReliableWriteEnabled ?: false
+        get() = owner?.executor?.isReliableWriteEnabled ?: false
+
+    /** Cached restriction flag. */
+    private val _isRestricted by lazy { super.isRestricted() }
+    override fun isRestricted(): Boolean = _isRestricted
 
     /**
      * Executes the read operation specific to the implementation.
@@ -111,8 +115,13 @@ abstract class BaseRemoteDescriptor(
 
     final override suspend fun read(): ByteArray = withCallSite("read") {
         // Check whether the descriptor wasn't invalidated.
-        requireNotNull(owner) {
+        val owner = requireNotNull(owner) {
             throw InvalidAttributeException()
+        }
+
+        // Check whether accessing the attribute is permitted.
+        require(owner.executor.environment.isSystem || !isRestricted()) {
+            throw SecurityException("Reading descriptor $uuid is not permitted")
         }
 
         // Verify that the descriptor can be read.
@@ -162,8 +171,13 @@ abstract class BaseRemoteDescriptor(
 
     final override suspend fun write(data: ByteArray) = withCallSite("write") {
         // Check whether the descriptor wasn't invalidated.
-        requireNotNull(owner) {
+        val owner = requireNotNull(owner) {
             throw InvalidAttributeException()
+        }
+
+        // Check whether accessing the attribute is permitted.
+        require(owner.executor.environment.isSystem || !isRestricted()) {
+            throw SecurityException("Writing descriptor $uuid is not permitted")
         }
 
         // Verify that the descriptor can be written to.

--- a/core-android/src/main/java/no/nordicsemi/kotlin/ble/core/android/AndroidEnvironment.kt
+++ b/core-android/src/main/java/no/nordicsemi/kotlin/ble/core/android/AndroidEnvironment.kt
@@ -216,6 +216,10 @@ interface AndroidEnvironment : Environment {
         // https://cs.android.com/android/_/android/platform/packages/modules/Bluetooth/+/f4c525723297ede881a618bb325f4b78a9babb1c
         get() = androidSdkVersion < SdkVersion.CINNAMON_BUN || isBluetoothPrivilegedPermissionGranted
 
+    override val isSystem: Boolean
+        // System apps have Bluetooth Privileged permission granted.
+        get() = isBluetoothPrivilegedPermissionGranted
+
     /**
      * The local Bluetooth adapter name, or *null* if the required permission is not granted.
      */

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/Characteristic.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/Characteristic.kt
@@ -41,7 +41,7 @@ import kotlin.uuid.Uuid
  */
 interface Characteristic<D: Descriptor> {
 
-    companion object {
+    companion object Uuids {
         /** Device Name characteristic UUID. */
         val DEVICE_NAME: Uuid by lazy { Uuid.fromShortUuid(0x2A00) }
         /** Appearance characteristic UUID. */
@@ -54,6 +54,30 @@ interface Characteristic<D: Descriptor> {
         val PERIPHERAL_PREFERRED_CONNECTION_PARAMETERS: Uuid by lazy { Uuid.fromShortUuid(0x2A04) }
         /** Service Changed characteristic UUID. */
         val SERVICE_CHANGED: Uuid by lazy { Uuid.fromShortUuid(0x2A05) }
+
+        /**
+         * Set of restricted GATT characteristics.
+         *
+         * @see Service.Uuids.Restricted
+         */
+        private object Restricted {
+            /** The UUID of the Human Interface Device Service. */
+            val HID_UUID: Uuid by lazy { Uuid.fromShortUuid(0x1812) }
+            /**
+             * Set of Human Interface Device GATT characteristics.
+             */
+            val HID_CHARACTERISTICS: Set<Uuid> by lazy {
+                setOf(
+                    Uuid.fromShortUuid(0x2A4A), // HID Information
+                    Uuid.fromShortUuid(0x2A4B), // Report Map
+                    Uuid.fromShortUuid(0x2A4C), // HID Control Point
+                    Uuid.fromShortUuid(0x2A4D)  // Report
+                )
+            }
+            /** Checks whether the given [uuid] is restricted. */
+            fun contains(uuid: Uuid, serviceUuid: Uuid) =
+                serviceUuid == HID_UUID && uuid in HID_CHARACTERISTICS
+        }
     }
 
     /**
@@ -113,4 +137,10 @@ interface Characteristic<D: Descriptor> {
         it == CharacteristicProperty.NOTIFY ||
         it == CharacteristicProperty.INDICATE
     } && descriptors.any { it.isClientCharacteristicConfiguration }
+
+    /**
+     * Returns whether the service is restricted and accessing it will result in a
+     * [SecurityException].
+     */
+    fun isRestricted() = Restricted.contains(uuid, service.uuid) || service.isRestricted()
 }

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/Descriptor.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/Descriptor.kt
@@ -41,7 +41,7 @@ import kotlin.uuid.Uuid
  */
 interface Descriptor {
 
-    companion object {
+    companion object Uuids {
         /** Characteristic Extended Properties descriptor UUID. */
         val CHAR_EXT_PROP_UUID: Uuid by lazy { Uuid.fromShortUuid(0x2900) }
         /** Characteristic User Description descriptor UUID. */
@@ -139,4 +139,10 @@ interface Descriptor {
         uuid != CHAR_EXT_PROP_UUID &&
         uuid != CHAR_PRESENTATION_FORMAT_UUID &&
         uuid != CHAR_AGGREGATE_FORMAT_UUID
+
+    /**
+     * Returns whether reading or writing to the descriptor is restricted and will result
+     * in a [SecurityException].
+     */
+    fun isRestricted() = characteristic.isRestricted()
 }

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/Environment.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/Environment.kt
@@ -46,6 +46,8 @@ package no.nordicsemi.kotlin.ble.core
  * @property allowsBondRemoval Whether the device provides API to remove bond information from local host.
  * @property reportsConnectableFlag Whether the device provides information whether a scanned
  * Bluetooth LE advertising packet is connectable.
+ * @property isSystem Whether the app is running in a privileged environment and has access to
+ * restricted features.
  */
 interface Environment {
     val deviceName: String
@@ -56,4 +58,5 @@ interface Environment {
     val automaticallyRequestsMtu: Boolean
     val allowsBondRemoval: Boolean
     val reportsConnectableFlag: Boolean
+    val isSystem: Boolean
 }

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/Service.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/Service.kt
@@ -39,11 +39,54 @@ import kotlin.uuid.Uuid
  */
 sealed interface Service<C: Characteristic<*>> {
 
-    companion object {
+    companion object Uuids {
         /** The UUID of Generic Access Service. */
         val GENERIC_ACCESS_UUID: Uuid by lazy { Uuid.fromShortUuid(0x1800) }
         /** The UUID of Generic Attribute Service. */
         val GENERIC_ATTRIBUTE_UUID: Uuid by lazy { Uuid.fromShortUuid(0x1801) }
+
+        /**
+         * Set of restricted GATT Services.
+         *
+         * Accessing any attribute in those will result in a [SecurityException].
+         *
+         * The list is based on the following sources:
+         * * [GattUtil](https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/Bluetooth/android/app/src/com/android/bluetooth/gatt/GattUtil.kt)
+         * * [isRestrictedSrvcUuid](https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/Bluetooth/android/app/src/com/android/bluetooth/gatt/GattService.java;l=1654)
+         * * [HidHostService](https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/Bluetooth/android/app/src/com/android/bluetooth/hid/HidHostService.java)
+         */
+        private object Restricted {
+            /** The UUID of the Android TV Remote Service. */
+            val ANDROID_TV_REMOTE_UUID: Uuid by lazy { Uuid.parse("AB5E0001-5A21-4F05-BC7D-AF01F617B664") }
+            /** The UUID of the Android Head Tracker Service. */
+            val ANDROID_HEADTRACKER_UUID: Uuid by lazy { Uuid.parse("109b862f-50e3-45cc-8ea1-ac62de4846d1") }
+            /** The UUID of the Apple Notification Center Service (ANCS). */
+            val ANCS_UUID: Uuid by lazy { Uuid.parse("7905F431-B5CE-4E99-A40F-4B1E122D00D0") }
+            /** The UUID of the FIDO Service. */
+            val FIDO_SERVICE_UUID: Uuid by lazy { Uuid.fromShortUuid(0xFFFD) } // U2F
+            /** Set of LE Audio Services. */
+            val LE_AUDIO_SERVICE_UUIDS: Set<Uuid> by lazy {
+                setOf(
+                    Uuid.fromShortUuid(0x1843), // AICS
+                    Uuid.fromShortUuid(0x1844), // VCS
+                    Uuid.fromShortUuid(0x1845), // VOCS
+                    Uuid.fromShortUuid(0x1846), // CSIS
+                    Uuid.fromShortUuid(0x184E), // ASCS
+                    Uuid.fromShortUuid(0x184F), // BASS
+                    Uuid.fromShortUuid(0x1850), // PACS
+                    Uuid.fromShortUuid(0x1854), // HAP
+                )
+            }
+            /** Checks whether the given [uuid] is restricted. */
+            fun contains(uuid: Uuid) =
+                // 4 characteristics in HID service are restricted.
+                uuid == ANDROID_TV_REMOTE_UUID ||
+                uuid == ANDROID_HEADTRACKER_UUID ||
+                // uuid == ANCS_UUID ||
+                uuid == FIDO_SERVICE_UUID ||
+                uuid in LE_AUDIO_SERVICE_UUIDS
+            // TODO Test LE Audio and ANCS on a real device
+        }
     }
 
     /**
@@ -65,6 +108,12 @@ sealed interface Service<C: Characteristic<*>> {
      * List of included secondary services.
      */
     val includedServices: List<IncludedService<C>>
+
+    /**
+     * Returns whether the service is restricted and accessing it will result in a
+     * [SecurityException].
+     */
+    fun isRestricted() = Restricted.contains(uuid)
 }
 
 /**

--- a/environment-android-mock/src/main/java/no/nordicsemi/kotlin/ble/environment/android/mock/MockAndroidEnvironment.kt
+++ b/environment-android-mock/src/main/java/no/nordicsemi/kotlin/ble/environment/android/mock/MockAndroidEnvironment.kt
@@ -261,6 +261,8 @@ sealed class MockAndroidEnvironment(
      * @param deviceName The device name, by default set to "Mock".
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
+     * @param isSystemApp Whether the app is running with system permissions. This is equivalent of
+     * BLUETOOTH_PRIVILEGED permission added in API 19.
      * @param issueOnlyOneActiveScan Some early Android devices were sending only one Scan Request
      * message for a single device per scan. Non-connectable devices were reported continuously, but
      * connectable devices were reported only once. The client had to stop and start scanning again
@@ -270,12 +272,14 @@ sealed class MockAndroidEnvironment(
         deviceName: String = DEFAULT_NAME,
         isBluetoothSupported: Boolean = true,
         isBluetoothEnabled: Boolean = true,
+        isSystemApp: Boolean = false,
         issueOnlyOneActiveScan: Boolean = false,
     ): MockAndroidEnvironment(
         androidSdkVersion = AndroidEnvironment.SdkVersion.JELLY_BEAN_MR2,
         deviceName = deviceName,
         isBluetoothSupported = isBluetoothSupported,
         isBluetoothEnabled = isBluetoothEnabled,
+        isBluetoothPrivilegedPermissionGranted = isSystemApp,
         scanner = DEFAULT_MOCK_SCANNER,
         issueOnlyOneActiveScan = issueOnlyOneActiveScan,
     )
@@ -287,7 +291,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param issueOnlyOneActiveScan Some early Android devices were sending only one Scan Request
      * message for a single device per scan. Non-connectable devices were reported continuously, but
      * connectable devices were reported only once. The client had to stop and start scanning again
@@ -316,7 +320,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param isMultipleAdvertisementSupported Whether multi advertisement is supported by the chipset.
      * @param advertiser A callback that will be called when the app requests to advertise.
      * The callback should return TX power level used for mock advertising.
@@ -357,7 +361,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param maxLlMtu The maximum Link Layer MTU size in range 27 - 251.
      * @param isMultipleAdvertisementSupported Whether multi advertisement is supported by the chipset.
      * @param isLocationPermissionGranted Whether the fine location permission is initially granted.
@@ -416,7 +420,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param isMultipleAdvertisementSupported Whether multi advertisement is supported by the chipset.
      * @param isLeExtendedAdvertisingSupported Whether LE Extended Advertising feature is supported.
      * @param isLePeriodicAdvertisingSupported Whether LE Periodic Advertising feature is supported.
@@ -501,7 +505,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param isMultipleAdvertisementSupported Whether multi advertisement is supported by the chipset.
      * @param isLeExtendedAdvertisingSupported Whether LE Extended Advertising feature is supported.
      * @param isLePeriodicAdvertisingSupported Whether LE Periodic Advertising feature is supported.
@@ -597,7 +601,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param isMultipleAdvertisementSupported Whether multi advertisement is supported by the chipset.
      * @param isLeExtendedAdvertisingSupported Whether LE Extended Advertising feature is supported.
      * @param isLePeriodicAdvertisingSupported Whether LE Periodic Advertising feature is supported.
@@ -697,7 +701,7 @@ sealed class MockAndroidEnvironment(
      * @param isBluetoothSupported Whether Bluetooth is supported on the device.
      * @param isBluetoothEnabled Whether Bluetooth is enabled on the device.
      * @param isBluetoothPrivilegedPermissionGranted Whether the Bluetooth privileged permission is
-     * initially granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
+     * granted. This permission can only be granted in own AOSP builds, not for 3rd party apps.
      * @param isMultipleAdvertisementSupported Whether multi advertisement is supported by the chipset.
      * @param isLeExtendedAdvertisingSupported Whether LE Extended Advertising feature is supported.
      * @param isLePeriodicAdvertisingSupported Whether LE Periodic Advertising feature is supported.


### PR DESCRIPTION
This PR adds a new check from reading / writing restricted characteristics or desciptors beloning to them.

This is the normal behavior on Android. This library throws the same exception before the system can.
Even with other platforms, like iOS, added in the future, none of them should have access to these characteristics.