### PR TITLE
[Bugfix] Fixed service discovery deadlock

### DIFF
--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/GattEvent.kt
@@ -67,18 +67,23 @@ data class ConnectionStateChanged(val newState: ConnectionState) : GattEvent() {
 }
 
 /**
+ * Event indicating that the service discovery has completed.
+ */
+sealed class ServiceDiscoveryCompleted : GattEvent()
+
+/**
  * Event indicating that the services have changed.
  *
  * @param services The list of discovered remote services.
  */
-data class ServicesDiscovered(val services: List<RemoteService>) : GattEvent()
+data class ServicesDiscovered(val services: List<RemoteService>) : ServiceDiscoveryCompleted()
 
 /**
  * Event indicating that the service discovery has failed.
  *
  * @param reason The reason of the failure.
  */
-data class ServiceDiscoveryFailed(val reason: RemoteServices.Failed.Reason) : GattEvent()
+data class ServiceDiscoveryFailed(val reason: RemoteServices.Failed.Reason) : ServiceDiscoveryCompleted()
 
 /**
  * Event indicating that the services have changed.

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -1498,54 +1498,52 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      */
     internal suspend fun disconnect(reason: ConnectionState.Disconnected.Reason) = withCallSite("disconnect") {
         withContext(NonCancellable) {
-            OperationMutex.withLock {
-                // Depending on the state...
-                when (state.value) {
-                    is ConnectionState.Disconnected -> {
-                        // Make sure auto-connection is closed.
-                        close()
-                        return@withLock
-                    }
-
-                    is ConnectionState.Disconnecting -> {
-                        // Skip..
-                    }
-
-                    is ConnectionState.Connecting -> {
-                        // Cancel the connection attempt.
-                        logger?.trace(Layer.GAP) { "Cancelling connection to ${this@Peripheral}" }
-                        _state.update { ConnectionState.Disconnecting }
-                    }
-
-                    is ConnectionState.Connected -> {
-                        // Disconnect from the peripheral.
-                        logger?.trace(Layer.GAP) { "Disconnecting from ${this@Peripheral}" }
-                        _state.update { ConnectionState.Disconnecting }
-                    }
+            // Depending on the state...
+            when (state.value) {
+                is ConnectionState.Disconnected -> {
+                    // Make sure auto-connection is closed.
+                    close()
+                    return@withContext
                 }
 
-                // Disconnect and wait until it is disconnected, then close.
-                try {
-                    if (!impl.isClosed) {
-                        await(
-                            action = { impl.disconnect(reason) },
-                            condition = { it.isDisconnected },
-                            timeout = 500.milliseconds
-                        )
-                    }
-                } catch (e: TimeoutCancellationException) {
-                    if (!isDisconnected) {
-                        logger?.warn(Layer.GAP) { "Disconnection takes longer than expected, closing" }
-                    }
-                } finally {
-                    close()
-                    // If before calling disconnect() the state was not Connected (i.e. Connecting),
-                    // the state at this point will be Disconnecting. Change it to Disconnected manually.
-                    _state.compareAndSet(
-                        expect = ConnectionState.Disconnecting,
-                        update = ConnectionState.Disconnected(reason)
+                is ConnectionState.Disconnecting -> {
+                    // Skip..
+                }
+
+                is ConnectionState.Connecting -> {
+                    // Cancel the connection attempt.
+                    logger?.trace(Layer.GAP) { "Cancelling connection to ${this@Peripheral}" }
+                    _state.update { ConnectionState.Disconnecting }
+                }
+
+                is ConnectionState.Connected -> {
+                    // Disconnect from the peripheral.
+                    logger?.trace(Layer.GAP) { "Disconnecting from ${this@Peripheral}" }
+                    _state.update { ConnectionState.Disconnecting }
+                }
+            }
+
+            // Disconnect and wait until it is disconnected, then close.
+            try {
+                if (!impl.isClosed) {
+                    await(
+                        action = { impl.disconnect(reason) },
+                        condition = { it.isDisconnected },
+                        timeout = 500.milliseconds
                     )
                 }
+            } catch (e: TimeoutCancellationException) {
+                if (!isDisconnected) {
+                    logger?.warn(Layer.GAP) { "Disconnection takes longer than expected, closing" }
+                }
+            } finally {
+                close()
+                // If before calling disconnect() the state was not Connected (i.e. Connecting),
+                // the state at this point will be Disconnecting. Change it to Disconnected manually.
+                _state.compareAndSet(
+                    expect = ConnectionState.Disconnecting,
+                    update = ConnectionState.Disconnected(reason)
+                )
             }
         }
     }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -66,7 +66,6 @@ import no.nordicsemi.kotlin.ble.client.internal.OperationMutex
 import no.nordicsemi.kotlin.ble.core.Characteristic
 import no.nordicsemi.kotlin.ble.core.ConnectionState
 import no.nordicsemi.kotlin.ble.core.Environment
-import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.Peer
 import no.nordicsemi.kotlin.ble.core.Service
 import no.nordicsemi.kotlin.ble.core.WriteType
@@ -139,6 +138,11 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * A flag indicating that the service discovery was requested.
      */
     private var serviceDiscoveryRequested = false
+
+    /**
+     * A coroutine job that is used to start service discovery.
+     */
+    private var serviceDiscoveryJob: Job? = null
 
     /**
      * The list of service UUIDs requested for discovery.
@@ -364,13 +368,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
         _services.value.invalidate()
         _services.update { RemoteServices.Unknown }
         servicesDiscovered = false
-        if (OperationMutex.holdsLock(ServicesChanged)) {
-            try {
-                OperationMutex.unlock(ServicesChanged)
-            } catch (e: IllegalStateException) {
-                logger?.warn(Layer.GATT, e)
-            }
-        }
         // Note!
         // Don't clear the serviceDiscoveryRequested flag here.
         // It will be cleared when the peripheral is closed.
@@ -415,12 +412,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             }
 
             is ServicesDiscovered -> {
-                try {
-                    // Unlocks the lock locked in `discoverServices` below.
-                    OperationMutex.unlock(ServicesChanged)
-                } catch (e: IllegalStateException) {
-                    logger?.warn(Layer.GAP, e)
-                }
+                servicesDiscovered = true
                 logger?.info(Layer.GATT) { "Services discovered" }
                 // Assign the owner to each service, making them valid.
                 val services = event.services.onEach { it.owner = this }
@@ -470,12 +462,6 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
             }
 
             is ServiceDiscoveryFailed -> {
-                try {
-                    // Unlocks the lock locked in `discoverServices` below.
-                    OperationMutex.unlock(ServicesChanged)
-                } catch (e: IllegalStateException) {
-                    logger?.warn(Layer.GATT, e)
-                }
                 logger?.warn(Layer.GATT) { "Service discovery failed: ${event.reason}" }
                 invalidateServices()
                 _services.update { RemoteServices.Failed(event.reason) }
@@ -502,28 +488,31 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      * This method does nothing if [servicesDiscovered] is `true`.
      */
     private fun discoverServices(uuids: List<Uuid>) {
-        if (!servicesDiscovered) {
-            servicesDiscovered = true
-            scope.launch {
+        if (servicesDiscovered || serviceDiscoveryJob?.isActive == true) {
+            return
+        }
+        serviceDiscoveryJob = scope.launch {
+            OperationMutex.withLock {
                 try {
-                    // On older Android versions each Bluetooth operation needs to await its
-                    // callback before another one can be triggered. Otherwise, some callbacks
-                    // aren't called at all. I.e. discovering services while also requesting HIGH
-                    // connection priority makes only one of them to complete.
-                    OperationMutex.lock(ServicesChanged)
-                } catch (e: IllegalStateException) {
-                    logger?.warn(Layer.GATT, e)
-                }
-                logger?.trace(Layer.GATT) { "Discovering services" }
-                _services.update { RemoteServices.Discovering }
-                try {
-                    if (!impl.discoverServices(uuids)) {
-                        throw PeripheralNotConnectedException()
-                    }
-                } catch (e: Exception) {
-                    OperationMutex.unlock(ServicesChanged)
-                    logger?.error(Layer.GATT) { "Discovering services failed: ${e.message}" }
+                    impl.events
+                        .onSubscription {
+                            logger?.trace(Layer.GATT) { "Discovering services" }
+                            _services.update { RemoteServices.Discovering }
+                            if (!isConnected || !impl.discoverServices(uuids)) {
+                                throw PeripheralNotConnectedException()
+                            }
+                        }
+                        .takeWhile { !it.isDisconnectionEvent }
+                        .filterIsInstance<ServiceDiscoveryCompleted>()
+                        .firstOrNull()
+                        ?: throw PeripheralNotConnectedException()
+                } catch (e: CancellationException) {
                     throw e
+                } catch (e: PeripheralNotConnectedException) {
+                    _services.update { RemoteServices.Unknown }
+                } catch (e: Exception) {
+                    _services.update { RemoteServices.Failed(RemoteServices.Failed.Reason.InternalError) }
+                    logger?.error(Layer.GATT) { "Discovering services failed: ${e.message}" }
                 }
             }
         }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteServices.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteServices.kt
@@ -47,6 +47,8 @@ sealed class RemoteServices {
         sealed class Reason {
             /** Service discovery returned empty list of services. */
             data object EmptyResult : Reason()
+            /** Service discovery failed to start. */
+            data object InternalError : Reason()
             /** Service discovery finished with a different status than SUCCESS. */
             data class Unknown(val status: Int) : Reason()
         }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/OperationMutex.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/OperationMutex.kt
@@ -31,7 +31,6 @@
 
 package no.nordicsemi.kotlin.ble.client.internal
 
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -51,37 +50,5 @@ object OperationMutex {
      */
     suspend fun <T> withLock(owner: Any? = null, block: suspend () -> T): T {
         return lock.withLock(owner) { block() }
-    }
-
-    /**
-     * Locks this mutex, suspending caller until the lock is acquired (in other words, while the
-     * lock is held elsewhere).
-     *
-     * This suspending function is cancellable: if the Job of the current coroutine is canceled
-     * while this suspending function is waiting, this function immediately resumes with
-     * [CancellationException].
-     */
-    suspend fun lock(owner: Any? = null) {
-        lock.lock(owner)
-    }
-
-    /**
-     * Unlocks this mutex.
-     *
-     * Throws [IllegalStateException] if invoked on a mutex that is not locked or was locked with
-     * a different owner token (by identity).
-     */
-    fun unlock(owner: Any? = null) {
-        lock.unlock(owner)
-    }
-
-    /**
-     * Checks whether this mutex is locked by the specified owner.
-     *
-     * @param owner - The owner token to check.
-     * @return `true` if this mutex is locked by the given owner.
-     */
-    fun holdsLock(owner: Any): Boolean {
-        return lock.holdsLock(owner)
     }
 }


### PR DESCRIPTION
This PR fixes #337.

## Changes
1. `discoverServices()` now has single exit point. The lock is always unlocked.
2. `OperationMutex.lock(..)` and `OperationMutex.unlock(...)` were removed.
3. `disconnect()` no longer requires lock, so can be triggered even on a deadlock. All GATT operations that rely on an active connection listen to `isDIsconnectionEvent` and will cancel itself.
4. New service discovery failure reason: `InternalError` triggered when service discovery failed to start.